### PR TITLE
chore: fix i18n module warning about absolute paths

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -311,12 +311,13 @@ export default defineNuxtConfig({
     lazy: true,
     strategy: 'no_prefix',
     detectBrowserLanguage: false,
-    langDir: resolve('./locales'),
+    // relative to i18n dir on rootDir: not yet v4 compat layout
+    langDir: '../locales',
     defaultLocale: 'en-US',
     experimental: {
       generatedLocaleFilePathFormat: 'relative',
     },
-    vueI18n: resolve('./config/i18n.config.ts'),
+    vueI18n: './config/i18n.config.ts',
   },
   pwa,
   staleDep: {


### PR DESCRIPTION
This PR just changes the `langDir` to be relative to the default `i18n` folder from root and also removes `resolve` usage in the `vueI18n` entry.

related #9

/cc @shuuji3 