### PR TITLE
chore: remove 'elk' mentions from config files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   # - name: Discord Chat
-  #   url: https://chat.elk.zone
+  #   url: https://chat.nimbus.town
   #   about: Ask questions and discuss with other users in real time.
   - name: Questions & Discussions
     url: https://github.com/nimbus-zone/nimbus/discussions

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist
 .vite-inspect
 .netlify/
 .eslintcache
-elk-translation-status.json
+nimbus-translation-status.json
 
 public/emojis
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/node:lts-alpine AS base
 
 # Prepare work directory
-WORKDIR /elk
+WORKDIR /nimbus
 
 FROM base AS builder
 
@@ -35,23 +35,23 @@ ARG GID=911
 
 # Create a dedicated user and group
 RUN set -eux; \
-    addgroup -g $GID elk; \
-    adduser -u $UID -D -G elk elk;
+    addgroup -g $GID nimbus; \
+    adduser -u $UID -D -G nimbus nimbus;
 
-USER elk
+USER nimbus
 
 ENV NODE_ENV=production
 
-COPY --from=builder /elk/.output ./.output
+COPY --from=builder /nimbus/.output ./.output
 
 EXPOSE 5314/tcp
 
 ENV PORT=5314
 
 # Specify container only environment variables ( can be overwritten by runtime env )
-ENV NUXT_STORAGE_FS_BASE='/elk/data'
+ENV NUXT_STORAGE_FS_BASE='/nimbus/data'
 
 # Persistent storage data
-VOLUME [ "/elk/data" ]
+VOLUME [ "/nimbus/data" ]
 
 CMD ["node", ".output/server/index.mjs"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,12 @@
 services:
-  elk:
+  nimbus:
     build:
       context: .
       dockerfile: Dockerfile
     volumes:
-      # make sure this directory has the same ownership as the elk user from the Dockerfile
+      # make sure this directory has the same ownership as the nimbus user from the Dockerfile
       # otherwise Nimbus will not be able to store configs for accounts
-      # e.q. mkdir ./elk-storage; sudo chown 911:911 ./elk-storage
-      - './elk-storage:/elk/data'
+      # e.q. mkdir ./nimbus-storage; sudo chown 911:911 ./nimbus-storage
+      - './nimbus-storage:/nimbus/data'
     ports:
       - 5314:5314

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default await antfu(
       'public-dev/**',
       'public-staging/**',
       'https-dev-config/**',
-      'elk-translation-status.json',
+      'nimbus-translation-status.json',
       'docs/translation-status.json',
     ],
   },

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "pnpm run build"
 
 # Redirect to Discord server
 [[redirects]]
-from = "https://chat.elk.zone"
-to = "https://discord.gg/vAZSDU9J"
+from = "https://chat.nimbus.town"
+to = "https://discord.gg/JuFDMrTRSD"
 status = 301
 force = true

--- a/pages/settings/language/index.vue
+++ b/pages/settings/language/index.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { ElkTranslationStatus } from '~/types/translation-status'
+import type { NimbusTranslationStatus } from '~/types/translation-status'
 
 const { t, locale } = useI18n()
 
-const translationStatus: ElkTranslationStatus = await import('~/elk-translation-status.json').then(m => m.default)
+const translationStatus: NimbusTranslationStatus = await import('~/nimbus-translation-status.json').then(m => m.default)
 
 useHydratedHead({
   title: () => `${t('settings.language.label')} | ${t('nav.settings')}`,

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/docs/* https://docs.elk.zone/:splat 200
+/docs/* https://docs.nimbus.town/:splat 200
 /settings/* /index.html 200

--- a/scripts/prepare-translation-status.ts
+++ b/scripts/prepare-translation-status.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'node:buffer'
 import { readFile, writeFile } from 'node:fs/promises'
 import { createResolver } from '@nuxt/kit'
 import { flatten } from 'flat'
-import type { ElkTranslationStatus } from '~/types/translation-status'
+import type { NimbusTranslationStatus } from '~/types/translation-status'
 import { countryLocaleVariants, currentLocales } from '../config/i18n'
 
 export const localeData: [code: string, file: string[], title: string][]
@@ -107,13 +107,15 @@ async function prepareTranslationStatus() {
 
   const resolver = createResolver(import.meta.url)
 
+  console.info('Writing translation status...')
+
   await writeFile(
     resolver.resolve('../docs/translation-status.json'),
     JSON.stringify(sorted, null, 2),
     { encoding: 'utf-8' },
   )
 
-  const translationStatus: ElkTranslationStatus = {
+  const translationStatus: NimbusTranslationStatus = {
     total,
     locales: {
       'en-US': {
@@ -136,8 +138,10 @@ async function prepareTranslationStatus() {
     }
   })
 
+  console.info('Writing nimbus-translation-status.json...')
+
   await writeFile(
-    resolver.resolve('../elk-translation-status.json'),
+    resolver.resolve('../nimbus-translation-status.json'),
     JSON.stringify(translationStatus, null, 2),
     { encoding: 'utf-8' },
   )

--- a/types/translation-status.ts
+++ b/types/translation-status.ts
@@ -1,4 +1,4 @@
-export interface ElkTranslationStatus {
+export interface NimbusTranslationStatus {
   total: number
   locales: Record<string, {
     percentage: string


### PR DESCRIPTION
I have tried to limit the scope of the changes as much as possible to the items described in #6 , on the `Elk references` > `Config files` list.

- [x] The Docker image and service are now named `nimbus`
- [x] All the links in config files have been updated to the new domain `nimbus.town`
- [x] The translation status is now written in  `nimbus-translation-status.json`and is typed as `NimbusTranslationStatus`

I'm pretty confident theses changes should not break anything, except the Docker-related ones. To my knowledge, only updating names should not have any impact on how it runs, but I was not able to test it to confirm my intuition.