### PR TITLE
chore: update dev instructions to use pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,19 +39,12 @@ git checkout -b my-new-branch
 
 3. Run `pnpm dev` in Nimbus's root folder to start dev server or `pnpm dev:mocked` to start dev server with `@elkdev@universeodon.com` user.
 
-We recommend installing [ni](https://github.com/antfu/ni#ni), that will use the right package manager in each of your projects. If `ni` is installed, you can instead run:
-
-```
-ni
-nr dev
-```
-
 ### Testing
 
 Nimbus uses [Vitest](https://vitest.dev). You can run the test suite with:
 
 ```
-nr test
+pnpm test
 ```
 
 ### Running PWA on dev server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ For guidelines on contributing to the documentation, refer to the [docs README](
 
 ### Finding a way to contribute
 
-Nimbus is still in its early stages, and there are many ways to contribute. If are not sure where to start, check out [this discussion](https://github.com/nimbus-town/nimbus/discussions/23) for some ideas.
+Nimbus is still in its early stages, and there are many ways to contribute. If you are not sure where to start, check out [this discussion](https://github.com/nimbus-town/nimbus/discussions/23) for some ideas.
 
 ### Online
 
@@ -33,11 +33,35 @@ If you have [nvm](https://github.com/nvm-sh/nvm), you can run `nvm i` to install
 git checkout -b my-new-branch
 ```
 
-1. Run `pnpm i` in Nimbus's root folder
+1. Run `pnpm i --frozen-lockfile` in Nimbus's root folder
 
 2. Run `pnpm nuxi prepare` in Nimbus's root folder
 
 3. Run `pnpm dev` in Nimbus's root folder to start dev server or `pnpm dev:mocked` to start dev server with `@elkdev@universeodon.com` user.
+
+#### Troubleshooting
+
+If you encounter any issues with the installation, we suggest trying the following steps:
+
+- Reinstall the dependencies:
+
+1. Remove the `node_modules` folder in Nimbus's root folder
+2. If the `pnpm-lock.yaml` file was modified, revert the changes
+3. Retry the installation in the root folder with `pnpm i --frozen-lockfile`
+
+- Check that you are using the correct command to start the dev server:
+  - `pnpm dev` with `pnpm`
+
+If the issue persists, please open an issue.
+
+#### Adding a new dependency
+
+Since Nimbus is a monorepo using `pnpm` workspace, it's important to add new dependencies using the correct command:
+
+- for development dependencies: `pnpm add -D <dep> -w`
+- for production dependencies: `pnpm add <dep> -w`
+
+Alternatively, you can manually add the dependency to the corresponding `package.json` file, and then run `pnpm i` in Nimbus's root folder to install the new dependency.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,12 @@ pnpm run dev
 
 `Warning`: you will need `corepack` enabled, check out the [Nimbus Contributing Guide](./CONTRIBUTING.md) for a detailed guide on how to set up the project locally.
 
-We recommend installing [ni](https://github.com/antfu/ni#ni), that will use the right package manager in each of your projects. If `ni` is installed, you can instead run:
-
-```
-ni
-nr dev
-```
-
 ### Testing
 
 Nimbus uses [Vitest](https://vitest.dev). You can run the test suite with:
 
 ```
-nr test
+pnpm test
 ```
 
 ## 📲 PWA

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We're really excited that you're interested in contributing to Nimbus! Before su
 Clone the repository and run on the root folder:
 
 ```
-pnpm i
+pnpm i --frozen-lockfile
 pnpm run dev
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ You need the following to contribute to Nimbus's documentation:
 1. [Fork the Nimbus GitHub project](https://github.com/nimbus-town/nimbus/fork) into your own account.
 2. Clone your fork to your local machine. See [GitHub's instructions for more information](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#cloning-your-forked-repository).
 3. From your terminal, `cd` to the directory you cloned into (`cd nimbus` by default).
-4. Run `pnpm i` to install the project dependencies.
+4. Run `pnpm i --frozen-lockfile` to install the project dependencies.
 5. Run `pnpm --filter nimbus-docs dev` to run the development server.
 
 Once the server has started up, you can access the live preview at <http://localhost:3000/>. This preview reloads when you save changes to the documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Welcome to the Nimbus Docs
 
-The documentation site publishes to https://docs.nimbus.town. We use [Docus](https://docus.dev) to generate the site and deploy through Netlify.
+The documentation site publishes to <https://docs.nimbus.town>. We use [Docus](https://docus.dev) to generate the site and deploy through Netlify.
 
 ## Quickstart
 
@@ -17,17 +17,16 @@ You need the following to contribute to Nimbus's documentation:
   - Use `nvm install node` to upgrade to the latest version.
   - Refer to the [nvm docs](https://github.com/nvm-sh/nvm#installing-and-updating) for information on installing `nvm`.
 - pnpm installed on your machine. [See the pnpm documentation for installation instructions](https://pnpm.io/installation).
-- Optionally, install [ni](https://github.com/antfu/ni#ni). See [Local Setup](../README.md#local-setup) for more information.
 
 ### Install and Preview
 
 1. [Fork the Nimbus GitHub project](https://github.com/nimbus-town/nimbus/fork) into your own account.
 2. Clone your fork to your local machine. See [GitHub's instructions for more information](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#cloning-your-forked-repository).
 3. From your terminal, `cd` to the directory you cloned into (`cd nimbus` by default).
-4. Run `pnpm i` or `ni` to install the project dependencies.
-5. Run `pnpm --filter nimbus-docs dev` or `nr --filter nimbus-docs dev` to run the development server.
+4. Run `pnpm i` to install the project dependencies.
+5. Run `pnpm --filter nimbus-docs dev` to run the development server.
 
-Once the server has started up, you can access the live preview at http://localhost:3000/. This preview reloads when you save changes to the documentation.
+Once the server has started up, you can access the live preview at <http://localhost:3000/>. This preview reloads when you save changes to the documentation.
 
 ### Contributing
 
@@ -43,13 +42,15 @@ When you are ready to submit work back to the main Nimbus repo, create a pull re
 6. Go to your fork of the Nimbus project in your GitHub account.
 7. Select the **Pull Request** tab.
 8. Select **New Pull Request**.
-9.  Confirm the repo/branches to compare.
-   - The base repo should be **nimbus-town/nimbus**.
-   - The base branch should be **main**.
-   - The head repository should be your fork.
-   - Compare branch should be your working branch you want to submit.
+9. Confirm the repo/branches to compare.
+
+- The base repo should be **nimbus-town/nimbus**.
+- The base branch should be **main**.
+- The head repository should be your fork.
+- Compare branch should be your working branch you want to submit.
 
       If you don't see four drop-downs, be sure you are comparing across forks.
+
 10. Add a description of the changes your request makes.
 11. Select **Add Pull Request**.
 

--- a/docs/content/1.guide/3.contributing.md
+++ b/docs/content/1.guide/3.contributing.md
@@ -13,7 +13,7 @@ You can use [StackBlitz Codeflow](https://stackblitz.com/codeflow) to fix bugs o
 Clone the repository and run on the root folder:
 
 ```bash
-pnpm i
+pnpm i --frozen-lockfile
 pnpm run dev
 ```
 

--- a/docs/content/1.guide/3.contributing.md
+++ b/docs/content/1.guide/3.contributing.md
@@ -19,19 +19,12 @@ pnpm run dev
 
 `Warning`: you will need `corepack` enabled, check out the [Nimbus Contributing Guide](https://github.com/nimbus-town/nimbus/blob/main/CONTRIBUTING.md) for a detailed guide on how to set up the project locally.
 
-We recommend installing [ni](https://github.com/antfu/ni#ni), that will use the right package manager in each of your projects. If `ni` is installed, you can instead run:
-
-```bash
-ni
-nr dev
-```
-
 ## Testing
 
 Nimbus uses [Vitest](https://vitest.dev). You can run the test suite with:
 
 ```bash
-nr test
+pnpm test
 ```
 
 ## Translation status


### PR DESCRIPTION
A possible fix for #19, alternative to #21

If that's the direction we want to take, we can maybe uninstall `@antfu/ni` altogether from the project. I was not sure if it would break something so I did not touch it in this PR for now.