### PR TITLE
chore: Change occurences of "Mastodon" to "Bluesky" in locales files

### DIFF
--- a/locales/ca-valencia.json
+++ b/locales/ca-valencia.json
@@ -35,7 +35,7 @@
     "favourited": "Preferit",
     "publish": "Publica"
   },
-  "app_desc_short": "Un client web Mastodon àgil",
+  "app_desc_short": "Un client web Bluesky àgil",
   "app_logo": "Logo d'Nimbus",
   "attachment": {
     "remove_label": "Elimina l'adjunt"
@@ -108,7 +108,7 @@
       "desc3": "No inicies sessió amb el teu compte real."
     },
     "desc_highlight": "Espereu trobar alguns errors i que falten funcions ací i allà.",
-    "desc_para1": "Gràcies pel teu interès en provar Nimbus, el nostre client web Mastodon en procés",
+    "desc_para1": "Gràcies pel teu interès en provar Nimbus, el nostre client web Bluesky en procés",
     "desc_para2": "estem treballant de valent en el desenvolupament i en millorar-lo.",
     "desc_para3": "Per a impulsar el desenvolupament, pots patrocinar l'equip a través dels patrocis de GitHub. Esperem que gaudisques d'Nimbus!",
     "desc_para4": "Nimbus és de codi obert. Si vols ajudar amb proves, comentaris o contribucions,",
@@ -176,19 +176,19 @@
     "update": "Actualitza",
     "webmanifest": {
       "canary": {
-        "description": "Un client web àgil de Mastodon (canary)",
+        "description": "Un client web àgil de Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Un client web àgil de Mastodon (desenvolupament)",
+        "description": "Un client web àgil de Bluesky (desenvolupament)",
         "name": "Nimbus (desenvolupament)"
       },
       "preview": {
-        "description": "Un client web àgil de Mastodon (vista prèvia)"
+        "description": "Un client web àgil de Bluesky (vista prèvia)"
       },
       "release": {
-        "description": "Un client web àgil de Mastodon"
+        "description": "Un client web àgil de Bluesky"
       }
     }
   },
@@ -206,7 +206,7 @@
       "sponsors_body_3": "Si t'agrada l'aplicació, considera patrocinar-nos:"
     },
     "account_settings": {
-      "description": "Edita la configuració del teu compte a la interfície de Mastodon"
+      "description": "Edita la configuració del teu compte a la interfície de Bluesky"
     },
     "interface": {
       "default": " (per defecte)",
@@ -391,11 +391,11 @@
   },
   "user": {
     "add_existing": "Afig un compte existent",
-    "server_address_label": "Adreça del servidor de Mastodon",
+    "server_address_label": "Adreça del servidor de Bluesky",
     "sign_in_desc": "Inicia la sessió per a seguir perfils o etiquetes, marcar com a preferides, compartir i respondre a les publicacions, o interactuar des d'un compte en un servidor diferent.",
     "sign_in_notice_title": "Veient les dades públiques de: {0}",
     "sign_out_account": "Tanca {0}",
-    "tip_no_account": "Si encara no tens un compte de Mastodon, {0}.",
+    "tip_no_account": "Si encara no tens un compte de Bluesky, {0}.",
     "tip_register_account": "tria un servidor i registra't"
   },
   "visibility": {

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -74,7 +74,7 @@
     "switch_account": "Canvia de compte",
     "vote": "Vota"
   },
-  "app_desc_short": "Un client web àgil Mastodon",
+  "app_desc_short": "Un client web àgil Bluesky",
   "app_logo": "Logotip d'Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -172,7 +172,7 @@
       "title": "Vista prèvia del desplegament"
     },
     "desc_highlight": "Espereu alguns errors i característiques que falten aquí i allà.",
-    "desc_para1": "Gràcies pel vostre interès a provar Nimbus, el nostre client web en desenvolupament per a Mastodon!",
+    "desc_para1": "Gràcies pel vostre interès a provar Nimbus, el nostre client web en desenvolupament per a Bluesky!",
     "desc_para2": "Estem treballant intensament en el desenvolupament i millorant-lo amb el temps.",
     "desc_para3": "Per impulsar el desenvolupament, podeu patrocinar l'equip a través dels patrocinadors de GitHub. Esperem que gaudiu d'Nimbus!",
     "desc_para4": "Nimbus és de codi obert. Si voleu ajudar amb les proves, fer comentaris o contribuir-hi,",
@@ -283,22 +283,22 @@
     "update_available_short": "Actualitza Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Un client web àgil Mastodon (canari)",
+        "description": "Un client web àgil Bluesky (canari)",
         "name": "Nimbus (canari)",
         "short_name": "Nimbus (canari)"
       },
       "dev": {
-        "description": "Un client web àgil Mastodon (dev)",
+        "description": "Un client web àgil Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Un client web àgil Mastodon (vista prèvia)",
+        "description": "Un client web àgil Bluesky (vista prèvia)",
         "name": "Nimbus (vista prèvia)",
         "short_name": "Nimbus (vista prèvia)"
       },
       "release": {
-        "description": "Un client web àgil Mastodon",
+        "description": "Un client web àgil Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -322,7 +322,7 @@
       "version": "Versió"
     },
     "account_settings": {
-      "description": "Editeu la configuració del vostre compte a la interfície d'usuari de Mastodon",
+      "description": "Editeu la configuració del vostre compte a la interfície d'usuari de Bluesky",
       "label": "Configuració del compte"
     },
     "interface": {
@@ -572,12 +572,12 @@
   },
   "user": {
     "add_existing": "Afegeix un compte existent",
-    "server_address_label": "Adreça del servidor Mastodon",
+    "server_address_label": "Adreça del servidor Bluesky",
     "sign_in_desc": "Inicia sessió per seguir perfils o hashtags, preferir, compartir i respondre publicacions o interactuar des del vostre compte en un servidor diferent.",
     "sign_in_notice_title": "S'estan visualitzant {0} dades públiques",
     "sign_out_account": "Tanca la sessió {0}",
     "single_instance_sign_in_desc": "Inicieu la sessió per seguir perfils o hashtags, preferir, compartir i respondre publicacions.",
-    "tip_no_account": "Si encara no teniu cap compte de Mastodon, {0}.",
+    "tip_no_account": "Si encara no teniu cap compte de Bluesky, {0}.",
     "tip_register_account": "trieu el vostre servidor i registreu-ne un"
   },
   "visibility": {

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -47,7 +47,7 @@
     "switch_account": "Přepnout účet",
     "vote": "Hlasovat"
   },
-  "app_desc_short": "Nimbus - hbitý webklient pro Mastodon.",
+  "app_desc_short": "Nimbus - hbitý webklient pro Bluesky.",
   "app_logo": "logo Nimbus",
   "app_name": "Nimbus",
   "command": {
@@ -79,7 +79,7 @@
   },
   "help": {
     "desc_highlight": "Z toho důvodu může tu a tam nastat chyba nebo chybět nějaká ta funkce.",
-    "desc_para1": "Těší nás váš zájem o Nimbus - Mastodoní klient na kterém právě pracujeme.",
+    "desc_para1": "Těší nás váš zájem o Nimbus - Blueskyí klient na kterém právě pracujeme.",
     "desc_para2": "Pracujeme na vývoji a průběžně Nimbus vylepšujeme. Brzy ho zveřejníme jako open source a budete mít možnost přispět svou troškou do mlýna.",
     "desc_para3": "Předtím můžete přispět do klobouku našim vývojářům na níže uvedených odkazech:",
     "title": "Nimbus ještě není hotový"
@@ -230,10 +230,10 @@
   },
   "user": {
     "add_existing": "Přidat existující účet",
-    "server_address_label": "Adresa Mastodon serveru:",
+    "server_address_label": "Adresa Bluesky serveru:",
     "sign_in_desc": "Přihlaste se, abyste mohli sledovat profily nebo hashtagy, psát a sdílet příspěvky a odpovídat na ně na tomto nebo jiných serverech.",
     "sign_out_account": "Odhlásit {0}",
-    "tip_no_account": "Pokud nemáte účet na Mastodonu, {0}.",
+    "tip_no_account": "Pokud nemáte účet na Blueskyu, {0}.",
     "tip_register_account": "vyberte server a zaregistrujte se"
   },
   "visibility": {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -11,7 +11,7 @@
     "authorized": "Du hast die Folgeanfrage erlaubt",
     "avatar_description": "Avatar von {0}",
     "blocked_by": "Du wurdest von diesem Account geblockt",
-    "blocked_domains": "Geblockte Mastodon-Instanzen",
+    "blocked_domains": "Geblockte Bluesky-Instanzen",
     "blocked_users": "Gesperrte Accounts",
     "blocking": "Blockiert",
     "bot": "BOT",
@@ -86,7 +86,7 @@
     "switch_account": "Account wechseln",
     "vote": "Abstimmen"
   },
-  "app_desc_short": "Ein flinker Mastodon Web-Client",
+  "app_desc_short": "Ein flinker Bluesky Web-Client",
   "app_logo": "Nimbus Logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -198,7 +198,7 @@
       "title": "Vorschau bereitstellen"
     },
     "desc_highlight": "Erwarte hier und da einige Bugs und fehlende Funktionen.",
-    "desc_para1": "Danke für dein Interesse an Nimbus, unser noch in der Bearbeitung befindlicher, generischer Mastodon-Client!",
+    "desc_para1": "Danke für dein Interesse an Nimbus, unser noch in der Bearbeitung befindlicher, generischer Bluesky-Client!",
     "desc_para2": "Wir arbeiten stetig an der Entwicklung und verbessern ihn mit der Zeit. Und wir laden dich schon sehr bald ein uns zu helfen, sobald wir ihn Quelloffen machen!",
     "desc_para3": "Doch in der Zwischenzeit kannst du der Entwicklung aushelfen, indem du unsere Teammitglieder durch die unten stehenden Links unterstützt.",
     "desc_para4": "Nimbus ist Open Source. \nWenn du beim Testen helfen, Feedback geben oder einen Beitrag leisten möchtest,",
@@ -373,22 +373,22 @@
     "update_available_short": "Nimbus aktualisieren",
     "webmanifest": {
       "canary": {
-        "description": "Ein flinker Mastodon-Webclient (Canary)",
+        "description": "Ein flinker Bluesky-Webclient (Canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Ein flinker Mastodon-Webclient (dev)",
+        "description": "Ein flinker Bluesky-Webclient (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Ein flinker Mastodon-Webclient (Vorschau)",
+        "description": "Ein flinker Bluesky-Webclient (Vorschau)",
         "name": "Nimbus (Vorschau)",
         "short_name": "Nimbus (Vorschau)"
       },
       "release": {
-        "description": "Ein flinker Mastodon-Webclient",
+        "description": "Ein flinker Bluesky-Webclient",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -448,7 +448,7 @@
       "version": "Version"
     },
     "account_settings": {
-      "description": "Bearbeite Kontoeinstellungen in der Mastodon-Benutzeroberfläche",
+      "description": "Bearbeite Kontoeinstellungen in der Bluesky-Benutzeroberfläche",
       "label": "Account Einstellungen"
     },
     "interface": {
@@ -736,12 +736,12 @@
   },
   "user": {
     "add_existing": "Bestehendes Konto hinzufügen",
-    "server_address_label": "Mastodon Server Adresse",
+    "server_address_label": "Bluesky Server Adresse",
     "sign_in_desc": "Melde dich an, um Profilen oder Hashtags zu folgen, Beiträge zu favorisieren, zu teilen und zu beantworten oder von deinem Konto auf einem anderen Server aus zu interagieren.",
     "sign_in_notice_title": "Anzeigen von {0} öffentlichen Daten",
     "sign_out_account": "{0} abmelden",
     "single_instance_sign_in_desc": "Melde dich an, um Profile oder Hashtags zu verfolgen, Beiträge zu favorisieren, zu teilen und darauf zu antworten.",
-    "tip_no_account": "Wenn du noch kein Mastodon-Konto hast, {0}.",
+    "tip_no_account": "Wenn du noch kein Bluesky-Konto hast, {0}.",
     "tip_register_account": "wähle einen Server aus und registriere einen"
   },
   "visibility": {

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -84,7 +84,7 @@
     "switch_account": "Εναλλαγή λογαριασμού",
     "vote": "Ψήφος"
   },
-  "app_desc_short": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Mastodon",
+  "app_desc_short": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Bluesky",
   "app_logo": "Λογότυπο Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -196,7 +196,7 @@
       "title": "Εκκίνηση προεπισκόπησης"
     },
     "desc_highlight": "Αναμένονται μερικά σφάλματα και ελλείψεις δυνατοτήτων πού και πού.",
-    "desc_para1": "Ευχαριστούμε για το ενδιαφέρον σου να δοκιμάσεις το Nimbus, τον εν εξελίξει πελάτη Mastodon για τον ιστό!",
+    "desc_para1": "Ευχαριστούμε για το ενδιαφέρον σου να δοκιμάσεις το Nimbus, τον εν εξελίξει πελάτη Bluesky για τον ιστό!",
     "desc_para2": "Δουλεύουμε σκληρά στην ανάπτυξη και βελτίωσή του με τον καιρό.",
     "desc_para3": "Για την ενίσχυση της ανάπτυξης, μπορείς να χρηματοδοτήσεις την Ομάδα μέσω του GitHub Sponsors. Ελπίζουμε να απολαμβάνεις τον Nimbus!",
     "desc_para4": "Ο Nimbus είναι Ανοιχτού Κώδικα. Αν θες να βοηθήσεις με την αποσφαλμάτωση, να προσφέρεις σχόλια ή να συνεισφέρεις,",
@@ -369,22 +369,22 @@
     "update_available_short": "Ενημέρωση του Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Mastodon (canary)",
+        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Mastodon (dev)",
+        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Mastodon (preview)",
+        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Mastodon",
+        "description": "Ένας ελαφρώς προσαρμοσμένος πελάτης για το Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -444,7 +444,7 @@
       "version": "Έκδοση"
     },
     "account_settings": {
-      "description": "Επεξεργάσου τις ρυθμίσεις του λογαριασμού σου στο UI του Mastodon",
+      "description": "Επεξεργάσου τις ρυθμίσεις του λογαριασμού σου στο UI του Bluesky",
       "label": "Ρυθμίσεις λογαριασμού"
     },
     "interface": {
@@ -725,12 +725,12 @@
   },
   "user": {
     "add_existing": "Προσθήκη υπάρχοντος λογαριασμού",
-    "server_address_label": "Διεύθυνση Διακομιστή Mastodon",
+    "server_address_label": "Διεύθυνση Διακομιστή Bluesky",
     "sign_in_desc": "Συνδέσου για να ακολουθείς προφίλ ή ετικέτες, αγάπησε, μοιράσου και απάντησε σε αναρτήσεις ή αλληλεπίδρασε από τον λογαριασμό σου σε διαφορετικό διακομιστή.",
     "sign_in_notice_title": "Προβολή δημοσίων δεδομένων {0}",
     "sign_out_account": "Αποσύνδεση {0}",
     "single_instance_sign_in_desc": "Συνδέσου για να ακολουθείς προφίλ ή ετικέτες, αγάπησε, μοιράσου και απάντησε σε αναρτήσεις.",
-    "tip_no_account": "Αν δεν έχεις ακόμα λογαριασμό στο Mastodon, {0}.",
+    "tip_no_account": "Αν δεν έχεις ακόμα λογαριασμό στο Bluesky, {0}.",
     "tip_register_account": "Επίλεξε τον διακομιστή σου και εγγράψου"
   },
   "visibility": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -87,7 +87,7 @@
     "switch_account": "Switch account",
     "vote": "Vote"
   },
-  "app_desc_short": "A nimble Mastodon web client",
+  "app_desc_short": "A nimble Bluesky web client",
   "app_logo": "Nimbus Logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Preview deploy"
     },
     "desc_highlight": "Expect some bugs and missing features here and there.",
-    "desc_para1": "Nimbus is a nimble Mastodon web client. You can login to your Mastodon account and use it to interact with the fediverse.",
+    "desc_para1": "Nimbus is a nimble Bluesky web client. You can login to your Bluesky account and use it to interact with the fediverse.",
     "desc_para2": "Nimbus is Open Source and we're actively improving it as a community project. Join us and let's build it together!",
     "desc_para3": "To boost development, you can sponsor the Team through GitHub Sponsors. We hope you enjoy Nimbus!",
     "desc_para4": "If you'd like to report a bug, help us testing, give feedback, or contribute,",
@@ -375,22 +375,22 @@
     "update_available_short": "Update Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "A nimble Mastodon web client (canary)",
+        "description": "A nimble Bluesky web client (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "A nimble Mastodon web client (dev)",
+        "description": "A nimble Bluesky web client (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "A nimble Mastodon web client (preview)",
+        "description": "A nimble Bluesky web client (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "A nimble Mastodon web client",
+        "description": "A nimble Bluesky web client",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Version"
     },
     "account_settings": {
-      "description": "Edit your account settings in Mastodon UI",
+      "description": "Edit your account settings in Bluesky UI",
       "label": "Account settings"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Add an existing account",
-    "server_address_label": "Mastodon Server Address",
+    "server_address_label": "Bluesky Server Address",
     "sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts, or interact from your account on a different server.",
     "sign_in_notice_title": "Viewing {0} public data",
     "sign_out_account": "Sign out {0}",
     "single_instance_sign_in_desc": "Sign in to follow profiles or hashtags, favorite, share and reply to posts.",
-    "tip_no_account": "If you don't have a Mastodon account yet, {0}.",
+    "tip_no_account": "If you don't have a Bluesky account yet, {0}.",
     "tip_register_account": "pick your server and register one"
   },
   "visibility": {

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -75,7 +75,7 @@
   },
   "help": {
     "desc_highlight": "Es normal que aparezcan algunos errores y funcionalidades que aún estén en desarrollo.",
-    "desc_para1": "¡Gracias por tu interés en probar Nimbus, nuestro cliente genérico en desarrollo para Mastodon!",
+    "desc_para1": "¡Gracias por tu interés en probar Nimbus, nuestro cliente genérico en desarrollo para Bluesky!",
     "desc_para2": "Estamos haciendo lo posible para ir mejorando constantemente.",
     "desc_para4": "Nimbus es de código abierto. Si quieres probar para ayudar, opinar o contribuir,",
     "desc_para5": "contáctanos a través de GitHub"
@@ -134,7 +134,7 @@
       "sponsor_action": "Patrocina"
     },
     "account_settings": {
-      "description": "Actualiza los ajustes de tu cuenta en la interfaz de Mastodon.",
+      "description": "Actualiza los ajustes de tu cuenta en la interfaz de Bluesky.",
       "label": "Configuración de cuenta"
     },
     "interface": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -87,7 +87,7 @@
     "switch_account": "Cambiar cuenta",
     "vote": "Votar"
   },
-  "app_desc_short": "Un cliente web ágil para Mastodon",
+  "app_desc_short": "Un cliente web ágil para Bluesky",
   "app_logo": "Logotipo de Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Implementación de vista previa"
     },
     "desc_highlight": "Es normal encontrar algunos errores y características faltantes aquí y allá.",
-    "desc_para1": "¡Gracias por el interés en probar Nimbus, nuestro cliente genérico en desarrollo para Mastodon!",
+    "desc_para1": "¡Gracias por el interés en probar Nimbus, nuestro cliente genérico en desarrollo para Bluesky!",
     "desc_para2": "Estamos trabajando duro en el desarrollo y mejorándolo constantemente.",
     "desc_para3": "Para ayudar a impulsar el desarrollo, puedes patrocinar a los miembros de nuestro equipo con los enlaces a continuación. ¡Esperamos que estés disfrutando Nimbus!",
     "desc_para4": "Nimbus es de código abierto, si te gustaría ayudar probando, dando opinión o contribuyendo,",
@@ -375,22 +375,22 @@
     "update_available_short": "Actualiza Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Un cliente web ágil para Mastodon (canary)",
+        "description": "Un cliente web ágil para Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Un cliente web ágil para Mastodon (desarrollo)",
+        "description": "Un cliente web ágil para Bluesky (desarrollo)",
         "name": "Nimbus (desarrollo)",
         "short_name": "Nimbus (desarrollo)"
       },
       "preview": {
-        "description": "Un cliente web ágil para Mastodon (vista previa)",
+        "description": "Un cliente web ágil para Bluesky (vista previa)",
         "name": "Nimbus (vista previa)",
         "short_name": "Nimbus (vista previa)"
       },
       "release": {
-        "description": "Un cliente web ágil para Mastodon",
+        "description": "Un cliente web ágil para Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Versión"
     },
     "account_settings": {
-      "description": "Edita los ajustes de tu cuenta en la interfaz de Mastodon.",
+      "description": "Edita los ajustes de tu cuenta en la interfaz de Bluesky.",
       "label": "Ajustes de cuenta"
     },
     "interface": {
@@ -743,12 +743,12 @@
   },
   "user": {
     "add_existing": "Agregar una cuenta existente",
-    "server_address_label": "Dirección de servidor de Mastodon",
+    "server_address_label": "Dirección de servidor de Bluesky",
     "sign_in_desc": "Inicia sesión para seguir perfiles o etiquetas, marcar cómo favorita, compartir y responder a publicaciones, o interactuar con un servidor diferente con tu usuario.",
     "sign_in_notice_title": "Viendo información pública de {0}",
     "sign_out_account": "Cerrar sesión {0}",
     "single_instance_sign_in_desc": "Inicia sesión para seguir perfiles o etiquetas, marcar cómo favorita, compartir y responder a publicaciones.",
-    "tip_no_account": "Si aún no tienes una cuenta Mastodon, {0}.",
+    "tip_no_account": "Si aún no tienes una cuenta Bluesky, {0}.",
     "tip_register_account": "selecciona tu servidor y registrate"
   },
   "visibility": {

--- a/locales/eu-ES.json
+++ b/locales/eu-ES.json
@@ -87,7 +87,7 @@
     "switch_account": "Aldatu kontua",
     "vote": "Eman botoa"
   },
-  "app_desc_short": "Mastodon web-bezero arin bat",
+  "app_desc_short": "Bluesky web-bezero arin bat",
   "app_logo": "Nimbus-en logoa",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Aurrebista erabiltzen du"
     },
     "desc_highlight": "Oso litekeena da erroreak eta ezaugarriak faltan egotea aplikazioan zehar.",
-    "desc_para1": "Eskerrik asko interesagatik eta Nimbus probatzeagatik, amaitu gabe dagoen Mastodonerako web-bezero arin bat!",
+    "desc_para1": "Eskerrik asko interesagatik eta Nimbus probatzeagatik, amaitu gabe dagoen Blueskyerako web-bezero arin bat!",
     "desc_para2": "Gogor ari gara garapen- eta hobetze-lanetan.",
     "desc_para3": "Garapenari bultzada emateko, GitHub Sponsors aukerari esker eman diezaiokezu babesa taldeari. Espero dugu Nimbus gogoko izatea!",
     "desc_para4": "Nimbus kode irekikoa da. Laguntza eman nahi badiguzu probatzen, iritzia ematen edo kodea idazten,",
@@ -375,22 +375,22 @@
     "update_available_short": "Eguneratu Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Mastodon web-bezero arin bat (canary)",
+        "description": "Bluesky web-bezero arin bat (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Mastodon web-bezero arin bat (garapena)",
+        "description": "Bluesky web-bezero arin bat (garapena)",
         "name": "Nimbus (garapena)",
         "short_name": "Nimbus (garapena)"
       },
       "preview": {
-        "description": "Mastodon web-bezero arin bat (aurrebista)",
+        "description": "Bluesky web-bezero arin bat (aurrebista)",
         "name": "Nimbus (aurrebista)",
         "short_name": "Nimbus (aurrebista)"
       },
       "release": {
-        "description": "Mastodon web-bezero arin bat",
+        "description": "Bluesky web-bezero arin bat",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Bertsioa"
     },
     "account_settings": {
-      "description": "Editatu zure kontuaren ezarpenak Mastodonen interfazean",
+      "description": "Editatu zure kontuaren ezarpenak Blueskyen interfazean",
       "label": "Kontuaren ezarpenak"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Gehitu dagoeneko existitzen den kontu bat",
-    "server_address_label": "Mastodon zerbitzariaren helbidea",
+    "server_address_label": "Bluesky zerbitzariaren helbidea",
     "sign_in_desc": "Hasi saioa profil edo traolak jarraitzeko, eta bidalketak gogoko egiteko, partekatzeko, eta erantzuteko edo beste zerbitzari bateko kontuarekin elkarreragiteko.",
     "sign_in_notice_title": "{0}(e)ko datu publikoak ikusten",
     "sign_out_account": "Amaitu {0}(r)en saioa",
     "single_instance_sign_in_desc": "Hasi saioa profil edo traolak jarraitzeko, eta bidalketak gogoko egiteko, partekatzeko, eta erantzuteko.",
-    "tip_no_account": "Oraindik Mastodon kontua ez badaukazu, {0}.",
+    "tip_no_account": "Oraindik Bluesky kontua ez badaukazu, {0}.",
     "tip_register_account": "hautatu zerbitzaria eta eman izena"
   },
   "visibility": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -87,7 +87,7 @@
     "switch_account": "Vaihda tiliä",
     "vote": "Äänestä"
   },
-  "app_desc_short": "Ketterä verkkosovellus Mastodonille",
+  "app_desc_short": "Ketterä verkkosovellus Blueskyille",
   "app_logo": "Nimbus-logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Esijulkaisu"
     },
     "desc_highlight": "Saatat löytää bugeja ja puuttuvia ominaisuuksia sieltä täältä.",
-    "desc_para1": "Nimbus on ketterä verkkosovellus Mastodonille. Voit kirjautua sisään Mastodon-tilillesi ja olla sen avulla vuorovaikutuksessa fediversumin kanssa.",
+    "desc_para1": "Nimbus on ketterä verkkosovellus Blueskyille. Voit kirjautua sisään Bluesky-tilillesi ja olla sen avulla vuorovaikutuksessa fediversumin kanssa.",
     "desc_para2": "Nimbus on avointa lähdekoodia, ja me parantelemme sitä vilkkaasti yhteisöprojektina. Liity joukkoomme, niin rakennamme sitä yhdessä!",
     "desc_para3": "Voit auttaa kehityksessä tukemalla tiimiä GitHub-sponsorina. Toivomme, että nautit Nimbusin käytöstä!",
     "desc_para4": "Jos haluat ilmoittaa ohjelmontivirheestä, auttaa testauksessa, antaa palautetta tai osallistua,",
@@ -375,22 +375,22 @@
     "update_available_short": "Päivitä Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Ketterä verkkosovellus Mastodonille (canary-versio)",
+        "description": "Ketterä verkkosovellus Blueskyille (canary-versio)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Ketterä verkkosovellus Mastodonille (kehitysversio)",
+        "description": "Ketterä verkkosovellus Blueskyille (kehitysversio)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Ketterä verkkosovellus Mastodonille (esijulkaisu)",
+        "description": "Ketterä verkkosovellus Blueskyille (esijulkaisu)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Ketterä verkkosovellus Mastodonille",
+        "description": "Ketterä verkkosovellus Blueskyille",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Versio"
     },
     "account_settings": {
-      "description": "Muokkaa tiliasetuksiasi Mastodonin käyttöliittymässä",
+      "description": "Muokkaa tiliasetuksiasi Blueskyin käyttöliittymässä",
       "label": "Tiliasetukset"
     },
     "interface": {
@@ -743,12 +743,12 @@
   },
   "user": {
     "add_existing": "Lisää olemassa oleva tili",
-    "server_address_label": "Mastodon-palvelimen osoite",
+    "server_address_label": "Bluesky-palvelimen osoite",
     "sign_in_desc": "Kirjaudu sisään, niin voit seurata profiileja ja aihetunnisteita, lisätä julkaisuja suosikkeihin, jakaa niitä ja vastata niihin sekä olla vuorovaikutuksessa toiselta palvelimelta.",
     "sign_in_notice_title": "Näytetään palvelimen {0} julkiset tiedot",
     "sign_out_account": "Kirjaa ulos {0}",
     "single_instance_sign_in_desc": "Kirjaudu sisään, niin voit seurata profiileja ja aihetunnisteita, lisätä julkaisuja suosikkeihin, jakaa niitä ja vastata niihin.",
-    "tip_no_account": "Jos sinulla ei ole vielä Mastodon-tiliä, {0}.",
+    "tip_no_account": "Jos sinulla ei ole vielä Bluesky-tiliä, {0}.",
     "tip_register_account": "valitse palvelimesi ja luo tili"
   },
   "visibility": {

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -78,7 +78,7 @@
     "switch_account": "Changer de compte",
     "vote": "Voter"
   },
-  "app_desc_short": "Un client Mastodon fait avec 🧡",
+  "app_desc_short": "Un client Bluesky fait avec 🧡",
   "app_logo": "Logo Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -178,7 +178,7 @@
       "title": "Aperçu du déploiement"
     },
     "desc_highlight": "Il est possible de rencontrer, par-ci par-là, quelques bugs et fonctionnalités manquantes.",
-    "desc_para1": "Merci de l'intérêt pour Nimbus, notre client Mastodon en cours de développement !",
+    "desc_para1": "Merci de l'intérêt pour Nimbus, notre client Bluesky en cours de développement !",
     "desc_para2": "Nous travaillons dur sur le développement et l'améliorons au fur et à mesure. Nous allons open-sourcer l'application une fois qu'elle sera prête pour un usage public.",
     "desc_para3": "Pour supporter son développement, vous pouvez parrainer les membres de l'équipe avec les liens ci-dessous. Nous espérons que vous apprécierez Nimbus!",
     "desc_para4": "Avant cela, si vous voulez aider à tester, donner des retours ou contribuer",
@@ -338,22 +338,22 @@
     "update_available_short": "Mettre à jour Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Un client Web Mastodon (canary)",
+        "description": "Un client Web Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Un client Web Mastodon (dev)",
+        "description": "Un client Web Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Un client Web Mastodon (aperçu)",
+        "description": "Un client Web Bluesky (aperçu)",
         "name": "Nimbus (aperçu)",
         "short_name": "Nimbus (aperçu)"
       },
       "release": {
-        "description": "Un client Web Mastodon",
+        "description": "Un client Web Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -413,7 +413,7 @@
       "version": "Version"
     },
     "account_settings": {
-      "description": "Modifiez les paramètres de votre compte dans l'interface de Mastodon",
+      "description": "Modifiez les paramètres de votre compte dans l'interface de Bluesky",
       "label": "Paramètres de compte"
     },
     "interface": {
@@ -694,7 +694,7 @@
     "sign_in_notice_title": "Affichage de {0} données publiques",
     "sign_out_account": "Se déconnecter de {0}",
     "single_instance_sign_in_desc": "Connectez-vous pour suivre des profils ou des hashtags, aimer, partager et répondre aux messages.",
-    "tip_no_account": "Si vous n'avez pas encore de compte Mastodon, {0}.",
+    "tip_no_account": "Si vous n'avez pas encore de compte Bluesky, {0}.",
     "tip_register_account": "choisissez votre serveur et enregistrez-en un"
   },
   "visibility": {

--- a/locales/gl-ES.json
+++ b/locales/gl-ES.json
@@ -83,7 +83,7 @@
     "switch_account": "Cambiar de conta",
     "vote": "Votar"
   },
-  "app_desc_short": "Un cliente web áxil para Mastodon",
+  "app_desc_short": "Un cliente web áxil para Bluesky",
   "app_logo": "Logo de Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -183,7 +183,7 @@
       "title": "Instalar versión"
     },
     "desc_highlight": "É de agardar que haxa fallos e falten cousas por aquí e por alá.",
-    "desc_para1": "Grazas polo teu interese en probar Nimbus, o cliente web para Mastodon que estamos creando!",
+    "desc_para1": "Grazas polo teu interese en probar Nimbus, o cliente web para Bluesky que estamos creando!",
     "desc_para2": "traballamos arreo para desenvolvelo e melloralo.",
     "desc_para3": "Podes acelerar o desenvolvemento patrocinando ao Equipo en GitHub Sponsors. Agardamos que desfrutes de Nimbus!",
     "desc_para4": "Nimbus é Código Aberto. Se queres axudar probándoo, aportando a túa opinión, ou colaborando,",
@@ -344,22 +344,22 @@
     "update_available_short": "Actualizar Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Un cliente áxil para Mastodon (canary)",
+        "description": "Un cliente áxil para Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Un cliente áxil para Mastodon (dev)",
+        "description": "Un cliente áxil para Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Un cliente áxil para Mastodon (preview)",
+        "description": "Un cliente áxil para Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Un cliente áxil para Mastodon",
+        "description": "Un cliente áxil para Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -419,7 +419,7 @@
       "version": "Versión"
     },
     "account_settings": {
-      "description": "Edita a configuración da túa conta na interface de Mastodon",
+      "description": "Edita a configuración da túa conta na interface de Bluesky",
       "label": "Axustes da conta"
     },
     "interface": {
@@ -698,12 +698,12 @@
   },
   "user": {
     "add_existing": "Engadir unha conta existente.",
-    "server_address_label": "Enderezo do Servidor Mastodon",
+    "server_address_label": "Enderezo do Servidor Bluesky",
     "sign_in_desc": "Inicia sesión para seguir perfís e cancelos, favorecer, compartir ou responder a mensaxes, ou interactuar coa túa conta noutro servidor.",
     "sign_in_notice_title": "Vendo {0} datos públicos",
     "sign_out_account": "Pechar sesión {0}",
     "single_instance_sign_in_desc": "Inicia sesión para seguir perfís e cancelos, favorecer, compartir ou responder a mensaxes.",
-    "tip_no_account": "Se aínda non tes unha conta Mastodon, {0}.",
+    "tip_no_account": "Se aínda non tes unha conta Bluesky, {0}.",
     "tip_register_account": "elixe un servidor para crear unha"
   },
   "visibility": {

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -87,7 +87,7 @@
     "switch_account": "Fiók váltás",
     "vote": "Szavazás"
   },
-  "app_desc_short": "Egy fürge Mastodon kliens",
+  "app_desc_short": "Egy fürge Bluesky kliens",
   "app_logo": "Nimbus Logó",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Előzetes változatát telepítése"
     },
     "desc_highlight": "Számíthatsz néhány hibára és hiányzó funkcióra itt és ott.",
-    "desc_para1": "Köszönjük az érdeklődésedet és hogy kipróbálod az Nimbus folyamazban lévő és fejlesztés alatt álló Mastodon klienst!",
+    "desc_para1": "Köszönjük az érdeklődésedet és hogy kipróbálod az Nimbus folyamazban lévő és fejlesztés alatt álló Bluesky klienst!",
     "desc_para2": "keményen dolgozunk a fejlesztésen és a javításokon időről időre.",
     "desc_para3": "A fejlesztés lendületéhez tudod támogatni csapatunkat a GitHub szponoráción keresztül. Reméljük elnyeri tetszésedét az Nimbus!",
     "desc_para4": "Az Nimbus nyílt forráskódú. Ha segíteni akar a tesztelésben, adhat visszajelzést vagy hozzájárulást,",
@@ -375,22 +375,22 @@
     "update_available_short": "Nimbus frissítése",
     "webmanifest": {
       "canary": {
-        "description": "Egy fürge Mastodon web kliens (canary)",
+        "description": "Egy fürge Bluesky web kliens (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Egy fürge Mastodon web kliens (dev)",
+        "description": "Egy fürge Bluesky web kliens (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Egy fürge Mastodon web kliens (preview)",
+        "description": "Egy fürge Bluesky web kliens (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Egy fürge Mastodon web kliens",
+        "description": "Egy fürge Bluesky web kliens",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Verzió"
     },
     "account_settings": {
-      "description": "Szerkeszd fiókbeállításaid a Mastodonban.",
+      "description": "Szerkeszd fiókbeállításaid a Blueskyban.",
       "label": "Fiók beállítások"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Egy látező fiók hozzáadása",
-    "server_address_label": "Mastodon szerver címe",
+    "server_address_label": "Bluesky szerver címe",
     "sign_in_desc": "Jelentkezzen be profilok vagy címkék követéséhez, kedvencekhez, bejegyzések megosztásához és megválaszolásához, vagy egy másik szerveren lévő fiókjából való interakcióhoz.",
     "sign_in_notice_title": "{0} nyilvános adat megtekintése",
     "sign_out_account": "Kijelentkezés {0}",
     "single_instance_sign_in_desc": "Jelentkezzen be profilok vagy címkék követéséhez, kedvencei közé, bejegyzések megosztásához és megválaszolásához.",
-    "tip_no_account": "Ha még nincs Mastodon fiókod: {0}.",
+    "tip_no_account": "Ha még nincs Bluesky fiókod: {0}.",
     "tip_register_account": "válassz egy szervert és regisztrált egyet"
   },
   "visibility": {

--- a/locales/id-ID.json
+++ b/locales/id-ID.json
@@ -83,7 +83,7 @@
     "switch_account": "Ganti akun",
     "vote": "Pilih"
   },
-  "app_desc_short": "Klien web Mastodon yang gesit",
+  "app_desc_short": "Klien web Bluesky yang gesit",
   "app_logo": "Logo Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -183,7 +183,7 @@
       "title": "Pratinjau penerapan"
     },
     "desc_highlight": "Masih terdapat beberapa bug dan fitur yang hilang di sana-sini.",
-    "desc_para1": "Terima kasih atas minat Anda untuk mencoba Nimbus, klien web Mastodon kami yang sedang dalam proses penyempurnaan!",
+    "desc_para1": "Terima kasih atas minat Anda untuk mencoba Nimbus, klien web Bluesky kami yang sedang dalam proses penyempurnaan!",
     "desc_para2": "kami bekerja keras untuk mengembangkan dan memperbaikinya dari waktu ke waktu.",
     "desc_para3": "Untuk meningkatkan pengembangan, Anda dapat mensponsori Tim melalui Sponsor GitHub. \nKami harap Anda menikmati Nimbus!",
     "desc_para4": "Nimbus adalah Software Sumber Terbuka. \nJika Anda ingin membantu dalam pengujian, memberikan umpan balik, atau berkontribusi,",
@@ -344,22 +344,22 @@
     "update_available_short": "Perbarui Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Klien web Mastodon yang gesit (canary)",
+        "description": "Klien web Bluesky yang gesit (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Klien web Mastodon yang gesit (dev)",
+        "description": "Klien web Bluesky yang gesit (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Klien web Mastodon yang gesit (pratinjau)",
+        "description": "Klien web Bluesky yang gesit (pratinjau)",
         "name": "Nimbus (pratinjau)",
         "short_name": "Nimbus (pratinjau)"
       },
       "release": {
-        "description": "Klien web Mastodon yang gesit",
+        "description": "Klien web Bluesky yang gesit",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -419,7 +419,7 @@
       "version": "Versi"
     },
     "account_settings": {
-      "description": "Sunting pengaturan akun Anda di Mastodon UI",
+      "description": "Sunting pengaturan akun Anda di Bluesky UI",
       "label": "Pengaturan akun"
     },
     "interface": {
@@ -698,12 +698,12 @@
   },
   "user": {
     "add_existing": "Tambahkan akun yang ada",
-    "server_address_label": "Alamat Server Mastodon",
+    "server_address_label": "Alamat Server Bluesky",
     "sign_in_desc": "Masuk untuk mengikuti profil atau hashtag, favorit, berbagi dan membalas posting, atau berinteraksi dari akun Anda di server lain.",
     "sign_in_notice_title": "Menampilkan data publik {0}",
     "sign_out_account": "Keluar {0}",
     "single_instance_sign_in_desc": "Masuk untuk mengikuti profil atau hashtag, memfavoritkan, berbagi, dan membalas postingan.",
-    "tip_no_account": "Jika Anda belum memiliki akun Mastodon, {0}.",
+    "tip_no_account": "Jika Anda belum memiliki akun Bluesky, {0}.",
     "tip_register_account": "pilih server Anda dan daftarkan"
   },
   "visibility": {

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -87,7 +87,7 @@
     "switch_account": "Cambia account",
     "vote": "Vota"
   },
-  "app_desc_short": "Un client web agile per Mastodon",
+  "app_desc_short": "Un client web agile per Bluesky",
   "app_logo": "Logo Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Anteprima implementazione"
     },
     "desc_highlight": "Aspettati qualche bug e funzione mancante qua e là.",
-    "desc_para1": "Grazie per il tuo interesse a provare Nimbus, il nostro web client per Mastodon in corso d'opera!",
+    "desc_para1": "Grazie per il tuo interesse a provare Nimbus, il nostro web client per Bluesky in corso d'opera!",
     "desc_para2": "Stiamo lavorando sodo allo sviluppo e al suo miglioramento nel tempo.",
     "desc_para3": "Per sostenere lo sviluppo, puoi sponsorizzare il team tramite GitHub Sponsors. Speriamo ti piaccia Nimbus!",
     "desc_para4": "Nimbus è open source. Se hai voglia di testare, fornire feedback o contribuire,",
@@ -375,22 +375,22 @@
     "update_available_short": "Aggiorna Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Un client web agile per Mastodon (canary)",
+        "description": "Un client web agile per Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Un client web agile per Mastodon (dev)",
+        "description": "Un client web agile per Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Un client web agile per Mastodon (anteprima)",
+        "description": "Un client web agile per Bluesky (anteprima)",
         "name": "Nimbus (anteprima)",
         "short_name": "Nimbus (anteprima)"
       },
       "release": {
-        "description": "Un client web agile per Mastodon",
+        "description": "Un client web agile per Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Versione"
     },
     "account_settings": {
-      "description": "Modifica le impostazioni del tuo account su Mastodon",
+      "description": "Modifica le impostazioni del tuo account su Bluesky",
       "label": "Impostazioni account"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Aggiungi account esistente",
-    "server_address_label": "Indirizzo istanza Mastodon",
+    "server_address_label": "Indirizzo istanza Bluesky",
     "sign_in_desc": "Accedi per seguire profili o hashtag, apprezzare, condividere e rispondere a post o interagire dal tuo account su un'altra istanza.",
     "sign_in_notice_title": "Visualizzando {0} dati pubblici",
     "sign_out_account": "Esci {0}",
     "single_instance_sign_in_desc": "Accedi per seguire profili o hastag, apprezzare condividere o rispondere a post.",
-    "tip_no_account": "Se ancora non hai un account Mastodon, {0}.",
+    "tip_no_account": "Se ancora non hai un account Bluesky, {0}.",
     "tip_register_account": "scegli la tua istanza preferita e registrati"
   },
   "visibility": {

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -79,7 +79,7 @@
     "switch_account": "アカウントの切り替え",
     "vote": "投票"
   },
-  "app_desc_short": "軽快なMastodonウェブクライアント",
+  "app_desc_short": "軽快なBlueskyウェブクライアント",
   "app_logo": "Nimbusのロゴ",
   "app_name": "Nimbus",
   "attachment": {
@@ -179,7 +179,7 @@
       "title": "プレビューデプロイ"
     },
     "desc_highlight": "バグや足りない機能があちこちにある想定です。",
-    "desc_para1": "開発中のMastodonウェブクライアントのNimbusに興味を持って試してくれてありがとうございます！",
+    "desc_para1": "開発中のBlueskyウェブクライアントのNimbusに興味を持って試してくれてありがとうございます！",
     "desc_para2": "私たちは時間をかけて開発と改善に努めています。",
     "desc_para3": "開発を進めるために、GitHubスポンサーでチームをサポートできます。Nimbusを楽しんでくれることを願っています！",
     "desc_para4": "Nimbusはオープンソースです。テスト、フィードバックの提供、コントリビューションで開発を助けたい場合は",
@@ -340,22 +340,22 @@
     "update_available_short": "Nimbusをアップデート",
     "webmanifest": {
       "canary": {
-        "description": "軽快なMastodonウェブクライアント (canary)",
+        "description": "軽快なBlueskyウェブクライアント (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "軽快なMastodonウェブクライアント (dev)",
+        "description": "軽快なBlueskyウェブクライアント (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "軽快なMastodonウェブクライアント (preview)",
+        "description": "軽快なBlueskyウェブクライアント (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "軽快なMastodonウェブクライアント",
+        "description": "軽快なBlueskyウェブクライアント",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -415,7 +415,7 @@
       "version": "バージョン"
     },
     "account_settings": {
-      "description": "Mastodon UIでアカウントの設定を編集します",
+      "description": "Bluesky UIでアカウントの設定を編集します",
       "label": "アカウント設定"
     },
     "interface": {
@@ -692,12 +692,12 @@
   },
   "user": {
     "add_existing": "既存のアカウントを追加する",
-    "server_address_label": "Mastodonサーバーのアドレス",
+    "server_address_label": "Blueskyサーバーのアドレス",
     "sign_in_desc": "サインインすると、アカウントやハッシュタグのフォロー、お気に入りの追加、投稿の共有、投稿への返信のほか、異なるサーバー上のあなたのアカウントから交流できるようになります。",
     "sign_in_notice_title": "{0}の公開データを表示しています",
     "sign_out_account": "{0}からサインアウト",
     "single_instance_sign_in_desc": "サインインすると、プロファイルやハッシュタグのフォロー、投稿のお気に入り、共有、返信ができるようになります。",
-    "tip_no_account": "まだMastodonアカウントを持っていない場合は、{0}しましょう。",
+    "tip_no_account": "まだBlueskyアカウントを持っていない場合は、{0}しましょう。",
     "tip_register_account": "サーバーを選んでアカウントを登録"
   },
   "visibility": {

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -73,7 +73,7 @@
     "switch_account": "Wissel van account",
     "vote": "Stem"
   },
-  "app_desc_short": "Een vlotte Mastodon web client",
+  "app_desc_short": "Een vlotte Bluesky web client",
   "app_logo": "Nimbus Logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -112,7 +112,7 @@
   },
   "help": {
     "desc_highlight": "Je kunt hier en daar wat bugs of ontbrekende features verwachten.",
-    "desc_para1": "Bedankt voor je interesse in het uitproberen van Nimbus, onze Mastodon web client in-wording!",
+    "desc_para1": "Bedankt voor je interesse in het uitproberen van Nimbus, onze Bluesky web client in-wording!",
     "desc_para2": "we werken hard aan nieuwe ontwikkelingen en verbeteringen in de loop van de tijd.",
     "desc_para3": "Om de ontwikkelingen te versnellen, kun je het Team sponsoren via GitHub Sponsors. We hopen dat Nimbus je bevalt!",
     "desc_para4": "Nimbus is Open Source. Wil je meehelpen met testen, feedback of bijdragen,",
@@ -389,11 +389,11 @@
   },
   "user": {
     "add_existing": "Voeg een bestaand account toe",
-    "server_address_label": "Mastodon Server Address",
+    "server_address_label": "Bluesky Server Address",
     "sign_in_desc": "Log in om profielen te volgen of hashtags, markeer posts als favoriet, deel en reageer op posts, of reageer vanaf je account op een andere server.",
     "sign_in_notice_title": "Je bekijkt {0} publieke data",
     "sign_out_account": "Uitloggen {0}",
-    "tip_no_account": "Als je nog geen Mastodon account hebt, {0}.",
+    "tip_no_account": "Als je nog geen Bluesky account hebt, {0}.",
     "tip_register_account": "kies jouw server en registreer een account"
   },
   "visibility": {

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -75,7 +75,7 @@
     "switch_account": "Przełącz konto",
     "vote": "Zagłosuj"
   },
-  "app_desc_short": "Aplikacja webowa dla Mastodon",
+  "app_desc_short": "Aplikacja webowa dla Bluesky",
   "app_logo": "Nimbus Logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -175,7 +175,7 @@
       "title": "Wdrożenie wersji Preview"
     },
     "desc_highlight": "Możliwe jest napotkanie, tu i ówdzie, pewnych błędów i brakujących funkcjonalności.",
-    "desc_para1": "Dziękujemy za zainteresowanie Nimbus, naszym wciąż rozwijanym klientem Mastodon!",
+    "desc_para1": "Dziękujemy za zainteresowanie Nimbus, naszym wciąż rozwijanym klientem Bluesky!",
     "desc_para2": "ciężko pracujemy nad rozwojem i ulepszaniem go w miarę upływu czasu.",
     "desc_para3": "Aby przyspieszyć rozwój, możesz wspomóc Zespół za pośrednictwem GitHub Sponsors. Mamy nadzieję, że spodoba Ci się Nimbus!",
     "desc_para4": "Nimbus jest Open Source. Jeśli chcesz pomóc w testowaniu, przekazać opinię lub wnieść swój wkład,",
@@ -315,22 +315,22 @@
     "update_available_short": "Zaktualizuj Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Aplikacja webowa dla Mastodon (canary)",
+        "description": "Aplikacja webowa dla Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Aplikacja webowa dla Mastodon (dev)",
+        "description": "Aplikacja webowa dla Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Aplikacja webowa dla Mastodon (preview)",
+        "description": "Aplikacja webowa dla Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Aplikacja webowa dla Mastodon",
+        "description": "Aplikacja webowa dla Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -354,7 +354,7 @@
       "version": "Wersja"
     },
     "account_settings": {
-      "description": "Edytuj ustawienia swojego konta w Mastodon UI",
+      "description": "Edytuj ustawienia swojego konta w Bluesky UI",
       "label": "Ustawienia konta"
     },
     "interface": {
@@ -611,12 +611,12 @@
   },
   "user": {
     "add_existing": "Dodaj istniejące konto",
-    "server_address_label": "Adres serwera Mastodon",
+    "server_address_label": "Adres serwera Bluesky",
     "sign_in_desc": "Zaloguj się, aby obserwować profile lub hasztagi, dodawać do ulubionych, udostępniać i odpowiadać na wpisy lub wchodzić w interakcje ze swojego konta na innym serwerze.",
     "sign_in_notice_title": "Dane publiczne  {0}",
     "sign_out_account": "Wyloguj {0}",
     "single_instance_sign_in_desc": "Zaloguj się, aby obserwować profile lub hashtagi, dodawać do ulubionych, udostępniać i odpowiadać na posty.",
-    "tip_no_account": "Jeśli nie masz jeszcze konta Mastodon, {0}.",
+    "tip_no_account": "Jeśli nie masz jeszcze konta Bluesky, {0}.",
     "tip_register_account": "wybierz swój serwer i zarejestruj się"
   },
   "visibility": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -28,7 +28,7 @@
     "save": "Salvar",
     "save_changes": "Salvar alterações"
   },
-  "app_desc_short": "Uma aplicação web ágil para o Mastodon",
+  "app_desc_short": "Uma aplicação web ágil para o Bluesky",
   "command": {
     "compose_desc": "Escrever novo post"
   },
@@ -161,16 +161,16 @@
     "dismiss": "Ignorar",
     "webmanifest": {
       "canary": {
-        "description": "Uma aplicação web ágil para o Mastodon (canary)"
+        "description": "Uma aplicação web ágil para o Bluesky (canary)"
       },
       "dev": {
-        "description": "Uma aplicação web ágil para o Mastodon (dev)"
+        "description": "Uma aplicação web ágil para o Bluesky (dev)"
       },
       "preview": {
-        "description": "Uma aplicação web ágil para o Mastodon (preview)"
+        "description": "Uma aplicação web ágil para o Bluesky (preview)"
       },
       "release": {
-        "description": "Uma aplicação web ágil para o Mastodon"
+        "description": "Uma aplicação web ágil para o Bluesky"
       }
     }
   },
@@ -189,7 +189,7 @@
       "sponsors_body_3": "Se estiver curtindo o app, considere nos patrocinar:"
     },
     "account_settings": {
-      "description": "Edite as configurações da sua conta na interface do Mastodon"
+      "description": "Edite as configurações da sua conta na interface do Bluesky"
     },
     "interface": {
       "color_mode": "Plano de fundo",
@@ -350,11 +350,11 @@
   },
   "user": {
     "add_existing": "Adicionar conta existente",
-    "server_address_label": "Endereço do servidor do Mastodon",
+    "server_address_label": "Endereço do servidor do Bluesky",
     "sign_in_desc": "Entre para seguir perfis e hashtags, favoritar, compartilhar e responder posts ou interagir com sua conta em outro servidor.",
     "sign_in_notice_title": "Visualizando dados públicos de {0}",
     "single_instance_sign_in_desc": "Entre para seguir perfis e hashtags, favoritar, compartilhar e responder posts.",
-    "tip_no_account": "Se ainda não tiver uma conta do Mastodon, {0}.",
+    "tip_no_account": "Se ainda não tiver uma conta do Bluesky, {0}.",
     "tip_register_account": "escolha um servidor e cadastre-se"
   },
   "visibility": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -87,7 +87,7 @@
     "switch_account": "Mudar de conta",
     "vote": "Votar"
   },
-  "app_desc_short": "Uma ágil aplicação web para o Mastodon",
+  "app_desc_short": "Uma ágil aplicação web para o Bluesky",
   "app_logo": "Logo do Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Produção de pré-visualização"
     },
     "desc_highlight": "Espere alguns problemas e funcionalidades em falta.",
-    "desc_para1": "O Nimbus é uma ágil aplicação web para o Mastodon. Pode iniciar sessão com a sua conta Mastodon e utilizá-la para interagir com o fediverso.",
+    "desc_para1": "O Nimbus é uma ágil aplicação web para o Bluesky. Pode iniciar sessão com a sua conta Bluesky e utilizá-la para interagir com o fediverso.",
     "desc_para2": "O Nimbus é software de código aberto e estamos a aperfeiçoá-lo ativamente como um projeto comunitário. Junte-se a nós e vamos construí-lo juntos!",
     "desc_para3": "Para ajudar a impulsionar o desenvolvimento, pode patrocinar a Equipa através do GitHub Sponsors. Esperamos que aprecie o Nimbus!",
     "desc_para4": "Se quiser comunicar um erro, ajudar-nos a testar, dar feedback ou contribuir,",
@@ -375,22 +375,22 @@
     "update_available_short": "Atualizar Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Uma ágil aplicação web para o Mastodon (canary)",
+        "description": "Uma ágil aplicação web para o Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Uma ágil aplicação web para o Mastodon (dev)",
+        "description": "Uma ágil aplicação web para o Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Uma ágil aplicação web para o Mastodon (preview)",
+        "description": "Uma ágil aplicação web para o Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Uma ágil aplicação web para o Mastodon",
+        "description": "Uma ágil aplicação web para o Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Versão"
     },
     "account_settings": {
-      "description": "Editar as configurações da sua conta na aplicação web do Mastodon",
+      "description": "Editar as configurações da sua conta na aplicação web do Bluesky",
       "label": "Configurações da conta"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Adicionar uma conta existente",
-    "server_address_label": "Endereço do Servidor Mastodon",
+    "server_address_label": "Endereço do Servidor Bluesky",
     "sign_in_desc": "Inicie sessão, para seguir pessoas ou hashtags, adicionar aos favoritos, partilhar e responder a publicações, ou interagir a partir da sua conta de outro servidor.",
     "sign_in_notice_title": "A visualizar os dados públicos de {0}",
     "sign_out_account": "Desconectar {0}",
     "single_instance_sign_in_desc": "Inicie sessão, para seguir pessoas ou hashtags, adicionar aos favoritos, partilhar e responder a publicações.",
-    "tip_no_account": "Se ainda não tem uma conta Mastodon, {0}.",
+    "tip_no_account": "Se ainda não tem uma conta Bluesky, {0}.",
     "tip_register_account": "escolha um servidor e inscreva-se"
   },
   "visibility": {

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -76,7 +76,7 @@
     "switch_account": "Сменить учетную запись",
     "vote": "Ответить"
   },
-  "app_desc_short": "Открытый веб-клиент для Mastodon",
+  "app_desc_short": "Открытый веб-клиент для Bluesky",
   "app_logo": "Логотип Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -176,7 +176,7 @@
       "title": "Предварительная сборка"
     },
     "desc_highlight": "В приложении может недоставать некоторых функций, зато могут попадаться баги.",
-    "desc_para1": "Спасибо за участие в тестировании Nimbus, открытого веб-клиента для Mastodon!",
+    "desc_para1": "Спасибо за участие в тестировании Nimbus, открытого веб-клиента для Bluesky!",
     "desc_para2": "Мы усердно работаем над развитием приложения и постоянно его улучшаем.",
     "desc_para3": "А еще вы можете поддержать разработку, став спонсором нашей команды на GitHub Sponsors. Мы надеемся, что вам понравится Nimbus!",
     "desc_para4": "Nimbus является проектом с открытым исходным кодом. Если вы хотите помочь с тестированием, обратной связью или разработкой,",
@@ -335,22 +335,22 @@
     "update_available_short": "Обновить Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Открытый веб-клиент для Mastodon (canary)",
+        "description": "Открытый веб-клиент для Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Открытый веб-клиент для Mastodon (dev)",
+        "description": "Открытый веб-клиент для Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Открытый веб-клиент для Mastodon (preview)",
+        "description": "Открытый веб-клиент для Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Открытый веб-клиент для Mastodon",
+        "description": "Открытый веб-клиент для Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -410,7 +410,7 @@
       "version": "Версия"
     },
     "account_settings": {
-      "description": "Вы можете изменить параметры своей учетной записи в пользовательском интерфейсе Mastodon",
+      "description": "Вы можете изменить параметры своей учетной записи в пользовательском интерфейсе Bluesky",
       "label": "Настройки учетной записи"
     },
     "interface": {
@@ -669,12 +669,12 @@
   },
   "user": {
     "add_existing": "Добавить существующую учетную запись",
-    "server_address_label": "Адрес сервера Mastodon",
+    "server_address_label": "Адрес сервера Bluesky",
     "sign_in_desc": "Войдите, чтобы подписываться на профили и хэштеги, добавлять в избранное, делиться постами и отвечать на них, или использовать свою учетную запись с другого сервера",
     "sign_in_notice_title": "Просмотр публичных данных {0}",
     "sign_out_account": "Выйти из учетной записи {0}",
     "single_instance_sign_in_desc": "Войдите, чтобы подписаться на пользователей и хештеги, ставить лайки, делиться и отвечать на посты.",
-    "tip_no_account": "Если у вас еще нет учетной записи Mastodon, {0}.",
+    "tip_no_account": "Если у вас еще нет учетной записи Bluesky, {0}.",
     "tip_register_account": "выберите сервер и зарегистрируйтесь на нем"
   },
   "visibility": {

--- a/locales/tl-PH.json
+++ b/locales/tl-PH.json
@@ -84,7 +84,7 @@
     "switch_account": "Magpalit ng account",
     "vote": "Bumoto"
   },
-  "app_desc_short": "Isang mabilis na web client ng Mastodon",
+  "app_desc_short": "Isang mabilis na web client ng Bluesky",
   "app_logo": "Logo ng Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -196,7 +196,7 @@
       "title": "Preview deploy"
     },
     "desc_highlight": "Maaaring mayroon kang makikitang mga bug at kulang na features.",
-    "desc_para1": "Salamat sa iyong interes sa pagsubok ng Nimbus, ang aming work-in-progress na Mastodon web client!",
+    "desc_para1": "Salamat sa iyong interes sa pagsubok ng Nimbus, ang aming work-in-progress na Bluesky web client!",
     "desc_para2": "Dedikado kami sa pag-develop at pagpapabuti dito sa mga susunod na panahon.",
     "desc_para3": "Para mapalago pa ang proyekto, maaari mong i-sponsor ang Team sa pamamagitan ng GitHub Sponsors. Sana magustuhan mo ang Nimbus!",
     "desc_para4": "Ang Nimbus ay Open Source. Kung nais mong tumulong sa pagsubok, magbigay ng feedback, o mag-contribute,",
@@ -368,22 +368,22 @@
     "update_available_short": "I-update ang Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Isang mabilis na Mastodon web client (canary)",
+        "description": "Isang mabilis na Bluesky web client (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Isang mabilis na Mastodon web client (dev)",
+        "description": "Isang mabilis na Bluesky web client (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Isang mabilis na Mastodon web client (preview)",
+        "description": "Isang mabilis na Bluesky web client (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Isang mabilis na Mastodon web client",
+        "description": "Isang mabilis na Bluesky web client",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -443,7 +443,7 @@
       "version": "Bersyon"
     },
     "account_settings": {
-      "description": "I-edit ang iyong mga account setting sa Mastodon UI",
+      "description": "I-edit ang iyong mga account setting sa Bluesky UI",
       "label": "Mga account setting"
     },
     "interface": {
@@ -723,12 +723,12 @@
   },
   "user": {
     "add_existing": "Magdagdag ng kasalukuyang account",
-    "server_address_label": "Address ng Server ng Mastodon",
+    "server_address_label": "Address ng Server ng Bluesky",
     "sign_in_desc": "Mag-sign in upang sundan ang mga profile o hashtag, paborito, ibahagi at tumugon sa mga post, o makipag-ugnayan mula sa iyong account sa ibang server.",
     "sign_in_notice_title": "Pagtingin sa {0} pampublikong data",
     "sign_out_account": "Mag-sign out {0}",
     "single_instance_sign_in_desc": "Mag-sign in upang sundan ang mga profile o hashtag, paborito, ibahagi at tumugon sa mga post.",
-    "tip_no_account": "Kung wala ka pang Mastodon account, {0}.",
+    "tip_no_account": "Kung wala ka pang Bluesky account, {0}.",
     "tip_register_account": "piliin ang iyong server at magrehistro ng isa"
   },
   "visibility": {

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -75,7 +75,7 @@
     "switch_account": "Hesap değiştir",
     "vote": "Oy ver"
   },
-  "app_desc_short": "Hızlı bir Mastodon web istemcisi",
+  "app_desc_short": "Hızlı bir Bluesky web istemcisi",
   "app_logo": "Nimbus Logosu",
   "app_name": "Nimbus",
   "attachment": {
@@ -175,7 +175,7 @@
       "title": "Dağıtımı önizleyin"
     },
     "desc_highlight": "Orada burada bir kaç hata ve eksik özellik bekleyin.",
-    "desc_para1": "Nimbus'i, bizim çalışması devam eden Mastodon web istemcimizi, denemedeki ilginiz için teşekkürler!",
+    "desc_para1": "Nimbus'i, bizim çalışması devam eden Bluesky web istemcimizi, denemedeki ilginiz için teşekkürler!",
     "desc_para2": "Zaman içinde geliştirmek ve iyileştirmek için çok çalışıyoruz.",
     "desc_para3": "Geliştirmemizi hızlandırmak için takıma GitHub Sponsors üzerinden sponsor olabilirsinizi. Umarız Nimbus'i beğenirsiniz!",
     "desc_para4": "Nimbus açık kaynaklıdır. Test etmek, geri dönüş vermek veya katkıda bulunmak isterseniz,",
@@ -316,22 +316,22 @@
     "update_available_short": "Nimbus'i güncelle",
     "webmanifest": {
       "canary": {
-        "description": "Hızlı bir Mastodon web istemcisi (canary)",
+        "description": "Hızlı bir Bluesky web istemcisi (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Hızlı bir Mastodon web istemcisi (dev)",
+        "description": "Hızlı bir Bluesky web istemcisi (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Hızlı bir Mastodon web istemcisi (preview)",
+        "description": "Hızlı bir Bluesky web istemcisi (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Hızlı bir Mastodon web istemcisi",
+        "description": "Hızlı bir Bluesky web istemcisi",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -355,7 +355,7 @@
       "version": "Versiyon"
     },
     "account_settings": {
-      "description": "Mastodon UI'da hesap ayarlarını değiştir",
+      "description": "Bluesky UI'da hesap ayarlarını değiştir",
       "label": "Hesap ayarları"
     },
     "interface": {
@@ -614,12 +614,12 @@
   },
   "user": {
     "add_existing": "Var olan bir hesap ekle",
-    "server_address_label": "Mastodon Sunucu Adresi",
+    "server_address_label": "Bluesky Sunucu Adresi",
     "sign_in_desc": "Profilleri veya hashtag'leri takip etmek, favorilere eklemek, gönderileri paylaşmak ve yanıtlamak veya farklı bir sunucudaki hesabınızdan etkileşim kurmak için oturum açın.",
     "sign_in_notice_title": "{0} herkese açık veri görüntüleniyor",
     "sign_out_account": "{0} çıkış yap",
     "single_instance_sign_in_desc": "Profilleri veya hashtag'leri takip etmek, favorilere eklemek, gönderileri paylaşmak ve yanıtlamak için oturum açın.",
-    "tip_no_account": "Eğer bir Mastodon hesabınız yoksa, {0}.",
+    "tip_no_account": "Eğer bir Bluesky hesabınız yoksa, {0}.",
     "tip_register_account": "sunucunuzu seçin ve kaydolun"
   },
   "visibility": {

--- a/locales/uk-UA.json
+++ b/locales/uk-UA.json
@@ -85,7 +85,7 @@
     "switch_account": "Змінити обліковий запис",
     "vote": "Голосувати"
   },
-  "app_desc_short": "Спритний вебклієнт для Mastodon",
+  "app_desc_short": "Спритний вебклієнт для Bluesky",
   "app_logo": "Лоґо Nimbus",
   "app_name": "Nimbus",
   "attachment": {
@@ -195,7 +195,7 @@
       "title": "Попередній вигляд"
     },
     "desc_highlight": "Можете очікувати деякі помилки і відсутні функції тут і там.",
-    "desc_para1": "Nimbus є спритним вебклієнтом для Mastodon. Можете ввійти в обліковий Mastodon запис, через котрого взаємодіяти з Fediverse.",
+    "desc_para1": "Nimbus є спритним вебклієнтом для Bluesky. Можете ввійти в обліковий Bluesky запис, через котрого взаємодіяти з Fediverse.",
     "desc_para2": "Nimbus є відкритим ПЗ, котрого жваво покращуємо, як проєкт спільноти. Можете долучитися до нас і розвивати його разом!",
     "desc_para3": "Аби прискорити розробку, можете спонсорувати Команду через GitHub Sponsors. Сподіваємося, ви задоволені застосунком Nimbus!",
     "desc_para4": "Якщо хочете повідомити про помилку, допомогти з тестуванням, надіслати відгук чи зробити внесок,",
@@ -371,22 +371,22 @@
     "update_available_short": "Оновити Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Спритний вебклієнт для Mastodon (canary)",
+        "description": "Спритний вебклієнт для Bluesky (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Спритний вебклієнт для Mastodon (dev)",
+        "description": "Спритний вебклієнт для Bluesky (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Спритний вебклієнт для Mastodon (preview)",
+        "description": "Спритний вебклієнт для Bluesky (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Спритний вебклієнт для Mastodon",
+        "description": "Спритний вебклієнт для Bluesky",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -446,7 +446,7 @@
       "version": "Версія"
     },
     "account_settings": {
-      "description": "Правити налаштування облікового запису через інтерфейс Mastodon",
+      "description": "Правити налаштування облікового запису через інтерфейс Bluesky",
       "label": "Налаштування облікового запису"
     },
     "interface": {
@@ -737,12 +737,12 @@
   },
   "user": {
     "add_existing": "Додати наявний обліковий запис",
-    "server_address_label": "Адреса серверу Mastodon",
+    "server_address_label": "Адреса серверу Bluesky",
     "sign_in_desc": "Ввійти, аби підписатися на профілі або гаштаґи; уподобувати, відповідати на і ділитися з кимось дописи, або взаємодіяти з вашого облікового запису на іншому сервері.",
     "sign_in_notice_title": "Перегляд прилюдних даних {0}",
     "sign_out_account": "Вийти з {0}",
     "single_instance_sign_in_desc": "Ввійти, аби підписатися на профілі або гаштаґи; уподобувати, відповідати на і ділитися з кимось дописи.",
-    "tip_no_account": "Якщо не маєте облікового Mastodon запису, {0}.",
+    "tip_no_account": "Якщо не маєте облікового Bluesky запису, {0}.",
     "tip_register_account": "то можете підібрати сервер і долучитися"
   },
   "visibility": {

--- a/locales/vi-VN.json
+++ b/locales/vi-VN.json
@@ -87,7 +87,7 @@
     "switch_account": "Chuyển sang tài khoản khác",
     "vote": "Bình chọn"
   },
-  "app_desc_short": "Một ứng dụng web Mastodon nhanh nhẹn",
+  "app_desc_short": "Một ứng dụng web Bluesky nhanh nhẹn",
   "app_logo": "Nimbus Logo",
   "app_name": "Nimbus",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "Bản dựng"
     },
     "desc_highlight": "Sẽ có lỗi và một số tính năng bị thiếu.",
-    "desc_para1": "Nimbus là một ứng dụng web Mastodon nhanh nhẹn. Sử dụng để đăng nhập Mastodon và tương tác với Fediverse.",
+    "desc_para1": "Nimbus là một ứng dụng web Bluesky nhanh nhẹn. Sử dụng để đăng nhập Bluesky và tương tác với Fediverse.",
     "desc_para2": "Nimbus là Mã Nguồn Mở và chúng tôi cải tiến nó như một dự án cộng đồng. Hãy tham gia và cùng xây dựng!",
     "desc_para3": "Để thúc đẩy sự phát triển, bạn có thể tài trợ cho Nhóm thông qua GitHub Sponsors. Chúng tôi hy vọng bạn thích Nimbus!",
     "desc_para4": "Nếu bạn muốn thử nghiệm, đưa ra phản hồi hoặc đóng góp,",
@@ -375,22 +375,22 @@
     "update_available_short": "Cập nhật Nimbus",
     "webmanifest": {
       "canary": {
-        "description": "Một ứng dụng web Mastodon nhanh nhẹn (canary)",
+        "description": "Một ứng dụng web Bluesky nhanh nhẹn (canary)",
         "name": "Nimbus (canary)",
         "short_name": "Nimbus (canary)"
       },
       "dev": {
-        "description": "Một ứng dụng web Mastodon nhanh nhẹn (dev)",
+        "description": "Một ứng dụng web Bluesky nhanh nhẹn (dev)",
         "name": "Nimbus (dev)",
         "short_name": "Nimbus (dev)"
       },
       "preview": {
-        "description": "Một ứng dụng web Mastodon nhanh nhẹn (preview)",
+        "description": "Một ứng dụng web Bluesky nhanh nhẹn (preview)",
         "name": "Nimbus (preview)",
         "short_name": "Nimbus (preview)"
       },
       "release": {
-        "description": "Một ứng dụng web Mastodon nhanh nhẹn",
+        "description": "Một ứng dụng web Bluesky nhanh nhẹn",
         "name": "Nimbus",
         "short_name": "Nimbus"
       }
@@ -450,7 +450,7 @@
       "version": "Phiên bản"
     },
     "account_settings": {
-      "description": "Cài đặt tài khoản trong Mastodon UI",
+      "description": "Cài đặt tài khoản trong Bluesky UI",
       "label": "Cài đặt tài khoản"
     },
     "interface": {
@@ -744,12 +744,12 @@
   },
   "user": {
     "add_existing": "Thêm một tài khoản khác",
-    "server_address_label": "Địa chỉ máy chủ Mastodon",
+    "server_address_label": "Địa chỉ máy chủ Bluesky",
     "sign_in_desc": "Đăng nhập để theo dõi người dùng hoặc hashtag, thích, chia sẻ và trả lời tút hoặc tương tác từ tài khoản của bạn trên một máy chủ khác.",
     "sign_in_notice_title": "Đang xem {0} công khai",
     "sign_out_account": "Đăng xuất {0}",
     "single_instance_sign_in_desc": "Đăng nhập để theo dõi người dùng hoặc hashtag, thích, chia sẻ và trả lời tút",
-    "tip_no_account": "Nếu bạn chưa có tài khoản Mastodon, {0}.",
+    "tip_no_account": "Nếu bạn chưa có tài khoản Bluesky, {0}.",
     "tip_register_account": "chọn máy chủ và đăng ký"
   },
   "visibility": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -87,7 +87,7 @@
     "switch_account": "切换帐号",
     "vote": "投票"
   },
-  "app_desc_short": "一个灵巧的 Mastodon 客户端",
+  "app_desc_short": "一个灵巧的 Bluesky 客户端",
   "app_logo": "应用图标",
   "app_name": "鹿鸣",
   "attachment": {
@@ -199,7 +199,7 @@
       "title": "预览部署"
     },
     "desc_highlight": "可能会在某些地方出现一些 bug 或缺失的功能。",
-    "desc_para1": "感谢你有兴趣尝试鹿鸣，一个我们正在积极开发的通用 Mastodon 客户端。",
+    "desc_para1": "感谢你有兴趣尝试鹿鸣，一个我们正在积极开发的通用 Bluesky 客户端。",
     "desc_para2": "我们正在努力开发中，并随着时间的推移不断完善。",
     "desc_para3": "为了帮助促进开发，你可以通过以下链接赞助我们的团队成员。希望你喜欢鹿鸣！",
     "desc_para4": "鹿鸣是开源的，如果你愿意帮助测试、提供反馈或作出贡献，",
@@ -375,22 +375,22 @@
     "update_available_short": "更新鹿鸣",
     "webmanifest": {
       "canary": {
-        "description": "一个灵巧的 Mastodon 客户端（Canary）",
+        "description": "一个灵巧的 Bluesky 客户端（Canary）",
         "name": "鹿鸣 Canary",
         "short_name": "鹿鸣 Canary"
       },
       "dev": {
-        "description": "一个灵巧的 Mastodon 客户端（开发版）",
+        "description": "一个灵巧的 Bluesky 客户端（开发版）",
         "name": "鹿鸣 开发版",
         "short_name": "鹿鸣 开发版"
       },
       "preview": {
-        "description": "一个灵巧的 Mastodon 客户端（预览版）",
+        "description": "一个灵巧的 Bluesky 客户端（预览版）",
         "name": "鹿鸣 预览版",
         "short_name": "鹿鸣 预览版"
       },
       "release": {
-        "description": "一个灵巧的 Mastodon 客户端",
+        "description": "一个灵巧的 Bluesky 客户端",
         "name": "鹿鸣",
         "short_name": "鹿鸣"
       }
@@ -450,7 +450,7 @@
       "version": "版本"
     },
     "account_settings": {
-      "description": "在 Mastodon UI 中编辑你的账号设置",
+      "description": "在 Bluesky UI 中编辑你的账号设置",
       "label": "账号设置"
     },
     "interface": {
@@ -743,12 +743,12 @@
   },
   "user": {
     "add_existing": "添加现有帐户",
-    "server_address_label": "Mastodon 服务器地址",
+    "server_address_label": "Bluesky 服务器地址",
     "sign_in_desc": "登录后可关注其他人或标签、点赞、分享和回复帖文，或与不同服务器上的账号交互。",
     "sign_in_notice_title": "正在查看 {0} 的公共数据",
     "sign_out_account": "登出 {0}",
     "single_instance_sign_in_desc": "登录后可关注其他人或标签、收藏、分享和回复帖文。",
-    "tip_no_account": "如果您还没有 Mastodon 账户，{0}。",
+    "tip_no_account": "如果您还没有 Bluesky 账户，{0}。",
     "tip_register_account": "选择您的服务器并注册一个"
   },
   "visibility": {

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -73,7 +73,7 @@
     "switch_account": "切換帳號",
     "vote": "投票"
   },
-  "app_desc_short": "一個靈巧的 Mastodon 用戶端",
+  "app_desc_short": "一個靈巧的 Bluesky 用戶端",
   "app_logo": "鹿鳴 Logo",
   "app_name": "鹿鳴",
   "attachment": {
@@ -166,7 +166,7 @@
       "title": "預覽部署"
     },
     "desc_highlight": "可能會在某些地方出現一些 bug 或缺少的功能。",
-    "desc_para1": "感謝你有興趣嘗試鹿鳴，一個我們正在積極開發的通用 Mastodon 用戶端。",
+    "desc_para1": "感謝你有興趣嘗試鹿鳴，一個我們正在積極開發的通用 Bluesky 用戶端。",
     "desc_para2": "我們正在努力開發中，並隨著時間的推移不斷完善。",
     "desc_para3": "為了幫助促進開發，你可以通過以下連結贊助我們的團隊成員。希望你喜歡鹿鳴！",
     "desc_para4": "鹿鳴是開源的，如果你願意幫助測試、提供回饋或作出貢獻，",
@@ -277,22 +277,22 @@
     "update_available_short": "更新鹿鳴",
     "webmanifest": {
       "canary": {
-        "description": "一個靈巧的 Mastodon 用戶端（Canary）",
+        "description": "一個靈巧的 Bluesky 用戶端（Canary）",
         "name": "鹿鳴 Canary",
         "short_name": "鹿鳴 Canary"
       },
       "dev": {
-        "description": "一個靈巧的 Mastodon 用戶端（開發版）",
+        "description": "一個靈巧的 Bluesky 用戶端（開發版）",
         "name": "鹿鳴 開發版",
         "short_name": "鹿鳴 開發版"
       },
       "preview": {
-        "description": "一個靈巧的 Mastodon 用戶端（預覽版）",
+        "description": "一個靈巧的 Bluesky 用戶端（預覽版）",
         "name": "鹿鳴 預覽版",
         "short_name": "鹿鳴 預覽版"
       },
       "release": {
-        "description": "一個靈巧的 Mastodon 用戶端",
+        "description": "一個靈巧的 Bluesky 用戶端",
         "name": "鹿鳴",
         "short_name": "鹿鳴"
       }
@@ -316,7 +316,7 @@
       "version": "版本"
     },
     "account_settings": {
-      "description": "在 Mastodon UI 中編輯你的帳號設定",
+      "description": "在 Bluesky UI 中編輯你的帳號設定",
       "label": "帳號設定"
     },
     "interface": {
@@ -555,11 +555,11 @@
   },
   "user": {
     "add_existing": "加入現有帳號",
-    "server_address_label": "Mastodon 伺服器位置",
+    "server_address_label": "Bluesky 伺服器位置",
     "sign_in_desc": "登入後可追蹤其他人或標籤、點讚、分享和回覆貼文，或與不同伺服器上的帳號互動。",
     "sign_in_notice_title": "正在查看 {0} 的公共數據",
     "sign_out_account": "登出 {0}",
-    "tip_no_account": "如果您還沒有 Mastodon 帳號，{0}。",
+    "tip_no_account": "如果您還沒有 Bluesky 帳號，{0}。",
     "tip_register_account": "選擇您的伺服器並註冊一個"
   },
   "visibility": {


### PR DESCRIPTION
Updated all occurrences of "Mastodon" to "Bluesky" across all JSON locale files
by running a find-and-replace command from within the locales directory:

`sed -i 's/Mastodon/Bluesky/g' *.json`