### PR TITLE
fix: use fs driver for deployments

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -141,7 +141,8 @@ export default defineNuxtConfig({
   },
   appConfig: {
     storage: {
-      driver: process.env.NUXT_STORAGE_DRIVER ?? (isCI ? 'cloudflare' : 'fs'),
+      // driver: process.env.NUXT_STORAGE_DRIVER ?? (isCI ? 'cloudflare' : 'fs'), // TODO: add cloudflare driver back if necessary
+      driver: process.env.NUXT_STORAGE_DRIVER ?? 'fs',
     },
   },
   runtimeConfig: {


### PR DESCRIPTION
This fixes the netlify deployments for now as the cloudflare storage driver was not configured and will probably be unnecessary for the beginning (storing server lists) for bsky for now.