### PR TITLE
chore: replace elk references listed in "Content to update" section

### DIFF
--- a/components/common/CommonPreviewPrompt.vue
+++ b/components/common/CommonPreviewPrompt.vue
@@ -13,7 +13,7 @@ const build = useBuildInfo()
     </h2>
     <p>
       <i18n-t keypath="help.build_preview.desc1">
-        <NuxtLink :href="`https://github.com/elk-zone/elk/commit/${build.commit}`" target="_blank" text-rose hover:underline>
+        <NuxtLink :href="`https://github.com/nimbus-town/nimbus/commit/${build.commit}`" target="_blank" text-rose hover:underline>
           <code>{{ build.shortCommit }}</code>
         </NuxtLink>
       </i18n-t>

--- a/components/help/HelpPreview.vue
+++ b/components/help/HelpPreview.vue
@@ -25,23 +25,23 @@ const vAutoFocus = (el: HTMLElement) => el.focus()
     </p>
     <p>
       {{ $t('help.desc_para4') }}
-      <NuxtLink font-bold text-primary href="https://github.com/elk-zone/elk" target="_blank">
+      <NuxtLink font-bold text-primary href="https://github.com/nimbus-town/nimbus" target="_blank">
         {{ $t('help.desc_para5') }}
       </NuxtLink>
       {{ $t('help.desc_para6') }}
     </p>
-    <NuxtLink hover:text-primary href="https://github.com/sponsors/elk-zone" target="_blank">
+    <NuxtLink hover:text-primary href="https://github.com/sponsors/nimbus-town" target="_blank">
       {{ $t('help.desc_para3') }}
     </NuxtLink>
     <p flex="~ gap-2 wrap justify-center" mxa>
-      <template v-for="team of elkTeamMembers" :key="team.github">
+      <template v-for="team of nimbusTeamMembers" :key="team.github">
         <NuxtLink :href="team.link" target="_blank" external rounded-full transition duration-300 border="~ transparent" hover="scale-105 border-primary">
           <img :src="`/avatars/${team.github}-100x100.png`" :alt="team.display" rounded-full w-15 h-15 height="60" width="60">
         </NuxtLink>
       </template>
     </p>
     <p italic flex justify-center w-full>
-      <NuxtLink href="https://github.com/sponsors/elk-zone" target="_blank">
+      <NuxtLink href="https://github.com/sponsors/nimbus-town" target="_blank">
         <span text-xl font-script hover:text-primary transition duration-300>{{ $t('help.footer_team') }}</span>
       </NuxtLink>
     </p>

--- a/components/nav/NavFooter.vue
+++ b/components/nav/NavFooter.vue
@@ -37,7 +37,7 @@ function toggleDark() {
           text-lg
           i-ri-heart-3-line hover="i-ri-heart-3-fill text-rose"
           :aria-label="$t('settings.about.sponsor_action')"
-          href="https://github.com/sponsors/elk-zone"
+          href="https://github.com/sponsors/nimbus-town"
           target="_blank"
         />
       </CommonTooltip>
@@ -53,7 +53,7 @@ function toggleDark() {
       <NuxtLink
         v-if="buildInfo.env === 'release'"
         external
-        :href="`https://github.com/elk-zone/elk/releases/tag/v${buildInfo.version}`"
+        :href="`https://github.com/nimbus-town/nimbus/releases/tag/v${buildInfo.version}`"
         target="_blank"
         font-mono
       >
@@ -64,7 +64,7 @@ function toggleDark() {
         &middot;
         <NuxtLink
           external
-          :href="`https://github.com/elk-zone/elk/commit/${buildInfo.commit}`"
+          :href="`https://github.com/nimbus-town/nimbus/commit/${buildInfo.commit}`"
           target="_blank"
           font-mono
         >
@@ -83,15 +83,11 @@ function toggleDark() {
         </NuxtLink>
       </template>
       &middot;
-      <NuxtLink href="/m.webtoo.ls/@elk" target="_blank">
-        Mastodon
-      </NuxtLink>
-      &middot;
-      <NuxtLink href="https://chat.elk.zone" target="_blank" external>
+      <NuxtLink href="https://chat.nimbus.town" target="_blank" external>
         Discord
       </NuxtLink>
       &middot;
-      <NuxtLink href="https://github.com/elk-zone/elk" target="_blank" external>
+      <NuxtLink href="https://github.com/nimbus-town/nimbus" target="_blank" external>
         GitHub
       </NuxtLink>
     </div>

--- a/components/notification/NotificationSubscribePushNotificationError.vue
+++ b/components/notification/NotificationSubscribePushNotificationError.vue
@@ -36,14 +36,14 @@ const modelValue = defineModel<boolean>({ required: true })
     <p>{{ message }}</p>
     <p py-2>
       <i18n-t keypath="settings.notifications.push_notifications.subscription_error.error_hint">
-        <NuxtLink font-bold href="https://docs.elk.zone/pwa#faq" target="_blank" inline-flex="~ row" items-center gap-x-2>
-          https://docs.elk.zone/pwa#faq
+        <NuxtLink font-bold href="https://docs.nimbus.town/pwa#faq" target="_blank" inline-flex="~ row" items-center gap-x-2>
+          https://docs.nimbus.town/pwa#faq
           <span inline-block aria-hidden="true" i-ri:external-link-line class="rtl-flip" />
         </NuxtLink>
       </i18n-t>
     </p>
     <p py-2>
-      <NuxtLink font-bold text-primary href="https://github.com/elk-zone/elk" target="_blank" flex="~ row" items-center gap-x-2>
+      <NuxtLink font-bold text-primary href="https://github.com/nimbus-town/nimbus" target="_blank" flex="~ row" items-center gap-x-2>
         {{ $t('settings.notifications.push_notifications.subscription_error.repo_link') }}
         <span inline-block aria-hidden="true" i-ri:external-link-line class="rtl-flip" />
       </NuxtLink>

--- a/composables/about.ts
+++ b/composables/about.ts
@@ -9,7 +9,7 @@ export interface Team {
   sponsors?: string
 }
 
-export const elkTeamMembers: Team[] = [
+export const nimbusTeamMembers: Team[] = [
   {
     github: 'antfu',
     display: 'Anthony Fu',

--- a/composables/about.ts
+++ b/composables/about.ts
@@ -44,14 +44,14 @@ export const nimbusTeamMembers: Team[] = [
     twitter: 'userquin',
     mastodon: 'userquin@webtoo.ls',
     link: '/m.webtoo.ls/@userquin',
-    sponsors: 'elk-zone', // sponsors/userquin isn't enabled
+    sponsors: 'nimbus-town', // sponsors/userquin isn't enabled
   },
   {
     github: 'shuuji3',
     display: 'TAKAHASHI Shuuji',
     mastodon: 'shuuji3@webtoo.ls',
     link: '/m.webtoo.ls/@shuuji3',
-    sponsors: 'elk-zone', // sponsors/shuuji3 isn't enabled
+    sponsors: 'nimbus-town', // sponsors/shuuji3 isn't enabled
   },
 ].sort(() => Math.random() - 0.5)
 

--- a/docs/components/global/TranslationState.vue
+++ b/docs/components/global/TranslationState.vue
@@ -128,7 +128,7 @@ async function copyToClipboard() {
               </td>
               <td>
                 <NuxtLink
-                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
+                  :href="`https://pr.new/github.com/nimbus-town/nimbus/tree/main/locales/${useFile}`"
                   target="_blank"
                   class="codeflow"
                   title="Raise a PR with Codeflow (opens in new window)"
@@ -154,7 +154,7 @@ async function copyToClipboard() {
               <td><strong>{{ `${total}` }}</strong></td>
               <td>
                 <NuxtLink
-                  :href="`https://pr.new/github.com/elk-zone/elk/tree/main/locales/${useFile}`"
+                  :href="`https://pr.new/github.com/nimbus-town/nimbus/tree/main/locales/${useFile}`"
                   target="_blank"
                   class="codeflow"
                   title="Raise a PR with Codeflow (opens in new window)"

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -34,7 +34,7 @@ function handleShowCommit() {
     <template v-if="isHydrated">
       <SettingsItem
         :text="$t('settings.about.version')"
-        :to="showCommit ? `https://github.com/elk-zone/elk/commit/${buildInfo.commit}` : undefined"
+        :to="showCommit ? `https://github.com/nimbus-town/nimbus/commit/${buildInfo.commit}` : undefined"
         external target="_blank"
         @click="handleShowCommit"
       >
@@ -61,26 +61,19 @@ function handleShowCommit() {
     <SettingsItem
       :text="$t('nav.docs')"
       icon="i-ri:book-open-line"
-      to="https://docs.elk.zone/"
-      large target="_blank"
-    />
-
-    <SettingsItem
-      text="Mastodon"
-      icon="i-ri:mastodon-line"
-      to="/m.webtoo.ls/@elk"
+      to="https://docs.nimbus.town/"
       large target="_blank"
     />
     <SettingsItem
       text="Discord"
       icon="i-ri:discord-fill"
-      to="https://chat.elk.zone"
+      to="https://chat.nimbus.town"
       external large target="_blank"
     />
     <SettingsItem
       text="GitHub"
       icon="i-ri:github-fill"
-      to="https://github.com/elk-zone/elk"
+      to="https://github.com/nimbus-town/nimbus"
       external large target="_blank"
     />
 
@@ -105,7 +98,7 @@ function handleShowCommit() {
 
     <SettingsItem
       :text="$t('settings.about.sponsor_action')"
-      to="https://github.com/sponsors/elk-zone"
+      to="https://github.com/sponsors/nimbus-town"
       :description="$t('settings.about.sponsor_action_desc')"
       external large target="_blank"
     >

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -122,7 +122,7 @@ function handleShowCommit() {
       </p>
 
       <SettingsItem
-        v-for="team in elkTeamMembers" :key="team.github"
+        v-for="team in nimbusTeamMembers" :key="team.github"
         :text="team.display"
         :to="team.link"
         external target="_blank"

--- a/scripts/avatars.ts
+++ b/scripts/avatars.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'node:fs/promises'
 import fs from 'fs-extra'
 import { ofetch } from 'ofetch'
 import { join, resolve } from 'pathe'
-import { elkTeamMembers } from '../composables/about'
+import { nimbusTeamMembers } from '../composables/about'
 
 const avatarsDir = resolve('./public/avatars/')
 
@@ -22,7 +22,7 @@ async function download(url: string, fileName: string) {
 async function fetchAvatars() {
   await fs.ensureDir(avatarsDir)
 
-  await Promise.all(elkTeamMembers.reduce((acc, { github }) => {
+  await Promise.all(nimbusTeamMembers.reduce((acc, { github }) => {
     acc.push(...sizes.map(s => download(`https://github.com/${github}.png?size=${s}`, join(avatarsDir, `${github}-${s}x${s}.png`))))
     return acc
   }, [] as Promise<void>[]))

--- a/server/utils/shared.ts
+++ b/server/utils/shared.ts
@@ -1,20 +1,20 @@
+// @ts-expect-error virtual import
+import { env } from '#build-info'
+// @ts-expect-error virtual import
+import { driver } from '#storage-config'
 import { $fetch } from 'ofetch'
 import kv from 'unstorage/drivers/cloudflare-kv-http'
+
 import fs from 'unstorage/drivers/fs'
+
 import memory from 'unstorage/drivers/memory'
 
 import vercelKVDriver from 'unstorage/drivers/vercel-kv'
 
-import cached from '../cache-driver'
-
-// @ts-expect-error virtual import
-import { env } from '#build-info'
-
-// @ts-expect-error virtual import
-import { driver } from '#storage-config'
-
 import { APP_NAME } from '~/constants'
+
 import type { AppInfo } from '~/types'
+import cached from '../cache-driver'
 
 const storage = useStorage<AppInfo>()
 
@@ -53,7 +53,7 @@ async function fetchAppInfo(origin: string, server: string) {
     method: 'POST',
     body: {
       client_name: APP_NAME + (env !== 'release' ? ` (${env})` : ''),
-      website: 'https://elk.zone',
+      website: 'https://nimbus.town',
       redirect_uris: getRedirectURI(origin, server),
       scopes: 'read write follow push',
     },


### PR DESCRIPTION
I think we can check all checkboxes in "Content to update" in #6 with this PR.

There are two files not included in this PR but I think it's not necessary to replace them:
- `components/publish/PublishWidget.vue` - It has a reference only in code comment to Elk repository so we don't need to replace it.
- `modules/tauri/index.ts` - There's a reference to `elk-og.png` (app's preview image). I think we don't need to update for now as tauri app is not maintained now. We will be able to update it if we resume tauri app for Nimbus.